### PR TITLE
#3285113 Fix double redirect

### DIFF
--- a/plugin/WP/WPRedirectWrapper.php
+++ b/plugin/WP/WPRedirectWrapper.php
@@ -7,7 +7,6 @@ namespace onOffice\WPlugin\WP;
 class WPRedirectWrapper
 {
 	public function redirect( string $url ) {
-		wp_redirect( $url, 301 );
-		exit();
+		redirect_canonical($url);
 	}
 }


### PR DESCRIPTION
## Missing trailing slash lead to a double redirect
The URLs for detail pages are redirected, when they are not exactly right. For example "https://testinstanz-jmaa.onofficeweb.com/immodetails/27-schone-immobili" is redirected to "https://testinstanz-jmaa.onofficeweb.com/immodetails/27-schone-immobilie-in-aachen/".

Currently, there is an extra redirection. When "https://testinstanz-jmaa.onofficeweb.com/immodetails/27-schone-immobil" is visited, there is a 301 to "https://testinstanz-jmaa.onofficeweb.com/immodetails/27-schone-immobilie-in-aachen" (without trailing slash) and then a second 301 to "https://testinstanz-jmaa.onofficeweb.com/immodetails/27-schone-immobilie-in-aachen/".

Note that when using WPML, there is only one redirect.

## The second redirect happens because of canonical URLs
WordPress follows the concept of canonical URLs, meaning that between different ways of writing the same URL, one is picked as the standard one. It appears that the canonical should have a trailing slash. So after the plugin redirects, WordPress notices that the URL is not canonical and does a second redirect.

## Redirect directly to the canonical URL
We can use [`redirect_canonical()` ](https://developer.wordpress.org/reference/functions/redirect_canonical/) to redirect to the canonical URL in the first place.