### PR TITLE
"Show Estate Status" is not active by default for estate detail view

### DIFF
--- a/plugin/DataView/DataDetailView.php
+++ b/plugin/DataView/DataDetailView.php
@@ -135,7 +135,7 @@ class DataDetailView
 	private $_pageIdsHaveDetailShortCode = [];
 
 	/** @var bool */
-	private $_showStatus = 0;
+	private $_showStatus = 1;
 
 	/** @var int */
 	private $_movieLinks = MovieLinkTypes::MOVIE_LINKS_PLAYER;

--- a/tests/TestClassDataDetailView.php
+++ b/tests/TestClassDataDetailView.php
@@ -95,7 +95,7 @@ class TestClassDataDetailView
 		$this->assertEquals(true, $pDataDetailView->hasDetailView());
 		$this->assertEquals('', $pDataDetailView->getTemplate());
 		$this->assertEquals('', $pDataDetailView->getShortCodeForm());
-		$this->assertFalse($pDataDetailView->getShowStatus());
+		$this->assertTrue($pDataDetailView->getShowStatus());
 		$this->assertEquals(LinksTypes::LINKS_EMBEDDED, $pDataDetailView->getOguloLinks());
 		$this->assertEquals(LinksTypes::LINKS_DEACTIVATED, $pDataDetailView->getObjectLinks());
 		$this->assertEquals(LinksTypes::LINKS_DEACTIVATED, $pDataDetailView->getLinks());


### PR DESCRIPTION
related to issue https://github.com/onOffice-Web-Org/oo-wp-plugin/issues/349

chaged logs:
- update status default of _showStatus param from 0 to 1
- update unit tests 