### PR TITLE
Revert "P#77272 Reference estates wrongly counted in preview button"

### DIFF
--- a/js/onoffice-form-preview.js
+++ b/js/onoffice-form-preview.js
@@ -55,9 +55,7 @@
         return onoffice_form_preview_strings.amount_other.replace('%s', amount);
     }
 
-    const create_preview = (formElement, result, spinner) => {
-        const element = formElement.querySelector('input[data-estate-count-list]');
-        const amount = element.getAttribute('data-estate-count-list');
+    const create_preview = (formElement, amount, spinner) => {
         const preview_text = create_preview_text(amount);
         let submitElement = formElement.querySelector('input[type=submit]');
         submitElement.value = preview_text;

--- a/templates.dist/estate/SearchForm.php
+++ b/templates.dist/estate/SearchForm.php
@@ -33,10 +33,9 @@ if (count($visible) === 0) {
 				renderFieldEstateSearch($inputName, $properties);
 				echo '</div>';
 			endforeach;
-			?>
-            <div class="oo-searchformfield">
-				<input type="submit" value="<?php echo esc_attr__('Search', 'onoffice-for-wp-websites'); ?>"
-                       data-estate-count-list="<?php echo $pEstates->getEstateOverallCount(); ?>">
+			?>		
+			<div class="oo-searchformfield">
+				<input type="submit" value="<?php echo esc_attr__('Search', 'onoffice-for-wp-websites'); ?>">
 				<svg viewBox="0 0 30 30" id="spinner"></svg>
 			</div>
 		</div>


### PR DESCRIPTION
Reverts onOffice-Web-Org/oo-wp-plugin#325

Changing the js file means that existing, individualized templates will break. Unfortunately, I only discovered this in my last test.