### PR TITLE
Fix InvalidPathException in child theme

### DIFF
--- a/plugin/Template.php
+++ b/plugin/Template.php
@@ -137,9 +137,9 @@ class Template
 			$this->_templateName = substr( $this->_templateName, strpos( $this->_templateName, $pluginDirName ) );
 		}
 		if (__String::getNew($this->_templateName)->startsWith('onoffice-theme/')) {
-			$templatePath = realpath(get_stylesheet_directory().'/'.$this->_templateName);
-			if (!__String::getNew($templatePath)->startsWith(realpath(get_stylesheet_directory()))) {
-				throw new RuntimeException('Invalid template path');
+			$templatePath = realpath(get_theme_file_path($this->_templateName));
+			if ($templatePath === false) {
+				throw new RuntimeException('Invalid template path `' . get_theme_file_path($this->_templateName) . '`');
 			}
 			return $templatePath;
 		}


### PR DESCRIPTION
When a template from the parent theme folder is selected and you switched to a chlid theme, the code would throw an exception because the template was not found in the child theme.

This change lets the plugin find the template in the parent folder.

Note that when using a child theme, the parent theme's templates will not be displayed in the backend. This quick fix has the goal to prevent an unnecessary crash. Proper child theme support needs to be implemented separately.