### PR TITLE
35110 "Geo range search" - the coordinates in the property tiles can not be hidden

### DIFF
--- a/plugin/ViewFieldModifier/EstateViewFieldModifierTypeEstateGeoBase.php
+++ b/plugin/ViewFieldModifier/EstateViewFieldModifierTypeEstateGeoBase.php
@@ -97,8 +97,6 @@ abstract class EstateViewFieldModifierTypeEstateGeoBase
 
 		if ($pos !== false) {
 			unset($viewFields[$pos]);
-			$viewFields []= 'breitengrad';
-			$viewFields []= 'laengengrad';
 		}
 
 		return $viewFields;

--- a/tests/TestClassEstateViewFieldModifierTypeDefault.php
+++ b/tests/TestClassEstateViewFieldModifierTypeDefault.php
@@ -128,8 +128,6 @@ class TestClassEstateViewFieldModifierTypeDefault
 			'anotherField',
 			'moreFields',
 			'Underscore_field11',
-			'laengengrad',
-			'breitengrad',
 		];
 
 		$pEstateViewFieldModifierTypeDefault = $this->getPreconfiguredFieldModifier();

--- a/tests/TestClassEstateViewFieldModifierTypeDefault.php
+++ b/tests/TestClassEstateViewFieldModifierTypeDefault.php
@@ -151,8 +151,6 @@ class TestClassEstateViewFieldModifierTypeDefault
 			'reserviert',
 			'verkauft',
 			'vermarktungsart',
-			'breitengrad',
-			'laengengrad',
 		];
 
 		$pEstateViewFieldModifierTypeDefault = $this->getPreconfiguredFieldModifier();

--- a/tests/TestClassEstateViewFieldModifierTypeEstateGeoBase.php
+++ b/tests/TestClassEstateViewFieldModifierTypeEstateGeoBase.php
@@ -72,7 +72,7 @@ class TestClassEstateViewFieldModifierTypeEstateGeoBase
 		$viewFields = [GeoPosition::FIELD_GEO_POSITION, 'testField'];
 		$pViewFieldModifier = $this->generateMockObject($viewFields);
 
-		$expectedVisibleFields = ['breitengrad', 'laengengrad', 'testField'];
+		$expectedVisibleFields = ['testField'];
 		$this->assertEqualSets($expectedVisibleFields, $pViewFieldModifier->getVisibleFields());
 	}
 


### PR DESCRIPTION
related to https://github.com/onOffice-Web-Org/oo-wp-plugin/issues/539

changed log :
Update geo range search