### PR TITLE
42590 Fatal Error caused by the plugin when creating menu items with "onOffice" via ACF

### DIFF
--- a/plugin/Controller/AdminViewController.php
+++ b/plugin/Controller/AdminViewController.php
@@ -336,7 +336,7 @@ class AdminViewController
 
 		if (__String::getNew($hook)->contains('onoffice')) {
 			$pObject = $this->getObjectByHook($hook);
-			if ($pObject !== null) {
+			if ($pObject !== null && method_exists($pObject, 'doExtraEnqueues')) {
 				$pObject->doExtraEnqueues();
 			}
 		}


### PR DESCRIPTION
related to https://github.com/onOffice-Web-Org/oo-wp-plugin/issues/684
changed log:
Add condition check doExtraEnqueues with "onOffice" via ACF