### PR TITLE
52911 Bug fix for displaying reference property detail pages after Release v5.1

### DIFF
--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -478,7 +478,11 @@ class EstateList
 		if ($this->enableShowPriceOnRequestText() && !isset($requestParams['data']['preisAufAnfrage'])) {
 			$requestParams['data'][] = 'preisAufAnfrage';
 		}
-		if ($this->getShowReferenceEstate() === DataListView::HIDE_REFERENCE_ESTATE) {
+		if ($pListView->getName() === 'detail') {
+			if ($this->getViewRestrict()) {
+				$requestParams['filter']['referenz'][] = ['op' => '=', 'val' => 0];
+			}
+		} elseif ($this->getShowReferenceEstate() === DataListView::HIDE_REFERENCE_ESTATE) {
 			$requestParams['filter']['referenz'][] = ['op' => '=', 'val' => 0];
 		} elseif ($this->getShowReferenceEstate() === DataListView::SHOW_ONLY_REFERENCE_ESTATE) {
 			$requestParams['filter']['referenz'][] = ['op' => '=', 'val' => 1];


### PR DESCRIPTION
related to https://github.com/onOffice-Web-Org/oo-wp-plugin/issues/903
changed log:

Fix bug reference property detail pages