### PR TITLE
Fix missing parameter for applicant search form

### DIFF
--- a/plugin/Gui/AdminPageFormSettingsApplicantSearch.php
+++ b/plugin/Gui/AdminPageFormSettingsApplicantSearch.php
@@ -92,10 +92,14 @@ class AdminPageFormSettingsApplicantSearch
 	protected function generateMetaBoxes()
 	{
 		$pFormFormSpecific = $this->getFormModelByGroupSlug(self::FORM_VIEW_FORM_SPECIFIC);
-		$this->createMetaBoxByForm($pFormFormSpecific, 'side');
+		if($pFormFormSpecific !== null) {
+            $this->createMetaBoxByForm($pFormFormSpecific, 'side');
+        }
 
 		$pFormGeoPosition = $this->getFormModelByGroupSlug(self::FORM_VIEW_GEOFIELDS);
-		$this->createMetaBoxByForm($pFormGeoPosition, 'normal');
+		if($pFormGeoPosition !== null) {
+            $this->createMetaBoxByForm($pFormGeoPosition, 'normal');
+        }
 
 		parent::generateMetaBoxes();
 	}

--- a/plugin/Gui/AdminPageFormSettingsBase.php
+++ b/plugin/Gui/AdminPageFormSettingsBase.php
@@ -512,9 +512,6 @@ abstract class AdminPageFormSettingsBase
 	{
 		$pFormLayoutDesign = $this->getFormModelByGroupSlug(self::FORM_VIEW_LAYOUT_DESIGN);
 		$this->createMetaBoxByForm($pFormLayoutDesign, 'normal');
-
-        $pFormTaskConfig = $this->getFormModelByGroupSlug(self::FORM_VIEW_TASKCONFIG);
-        $this->createMetaBoxByForm($pFormTaskConfig, 'normal');
 	}
 
 

--- a/plugin/Gui/AdminPageFormSettingsBase.php
+++ b/plugin/Gui/AdminPageFormSettingsBase.php
@@ -511,7 +511,9 @@ abstract class AdminPageFormSettingsBase
 	protected function generateMetaBoxes()
 	{
 		$pFormLayoutDesign = $this->getFormModelByGroupSlug(self::FORM_VIEW_LAYOUT_DESIGN);
-		$this->createMetaBoxByForm($pFormLayoutDesign, 'normal');
+		if($pFormLayoutDesign !== null) {
+            $this->createMetaBoxByForm($pFormLayoutDesign, 'normal');
+        }
 	}
 
 

--- a/plugin/Gui/AdminPageFormSettingsContact.php
+++ b/plugin/Gui/AdminPageFormSettingsContact.php
@@ -327,6 +327,9 @@ class AdminPageFormSettingsContact
 		$this->createMetaBoxByForm($pFormActivities, 'side');
 
 		parent::generateMetaBoxes();
+
+        $pFormTaskConfig = $this->getFormModelByGroupSlug(self::FORM_VIEW_TASKCONFIG);
+        $this->createMetaBoxByForm($pFormTaskConfig, 'normal');
 	}
 
 

--- a/plugin/Gui/AdminPageFormSettingsContact.php
+++ b/plugin/Gui/AdminPageFormSettingsContact.php
@@ -316,20 +316,28 @@ class AdminPageFormSettingsContact
 	protected function generateMetaBoxes()
 	{
 		$pFormFormSpecific = $this->getFormModelByGroupSlug(self::FORM_VIEW_FORM_SPECIFIC);
-		$this->createMetaBoxByForm($pFormFormSpecific, 'side');
+        if($pFormFormSpecific !== null) {
+            $this->createMetaBoxByForm($pFormFormSpecific, 'side');
+        }
 
 		if ($this->_showGeoPositionSettings) {
 			$pFormGeoPosition = $this->getFormModelByGroupSlug(self::FORM_VIEW_GEOFIELDS);
-			$this->createMetaBoxByForm($pFormGeoPosition, 'side');
+			if($pFormGeoPosition !== null) {
+                $this->createMetaBoxByForm($pFormGeoPosition, 'side');
+            }
 		}
 
 		$pFormActivities = $this->getFormModelByGroupSlug(self::FORM_VIEW_FORM_ACTIVITYCONFIG);
-		$this->createMetaBoxByForm($pFormActivities, 'side');
+		if($pFormActivities !== null) {
+            $this->createMetaBoxByForm($pFormActivities, 'side');
+        }
 
 		parent::generateMetaBoxes();
 
         $pFormTaskConfig = $this->getFormModelByGroupSlug(self::FORM_VIEW_TASKCONFIG);
-        $this->createMetaBoxByForm($pFormTaskConfig, 'normal');
+        if($pFormTaskConfig !== null) {
+            $this->createMetaBoxByForm($pFormTaskConfig, 'normal');
+        }
 	}
 
 


### PR DESCRIPTION
Die parent Klasse darf nicht zum Rendern des "Task" Blocks verwendet werden, da nicht alle Formulare dieses Element besitzen.