### PR TITLE
Bug/T#4646119-special-char-search

### DIFF
--- a/plugin/Filter/FilterBuilderInputVariables.php
+++ b/plugin/Filter/FilterBuilderInputVariables.php
@@ -102,9 +102,9 @@ class FilterBuilderInputVariables
 	private function getFieldFilter($fieldValue, string $type): array
 	{
 		$fieldFilter = [];
-        if(is_string($fieldValue)){
-            $fieldValue = html_entity_decode($fieldValue);
-        }
+		if(is_string($fieldValue)){
+			$fieldValue = html_entity_decode($fieldValue);
+		}
 		if (FieldTypes::isNumericType($type) || FieldTypes::isDateOrDateTime($type)) {
 			if (!is_array($fieldValue)) {
 				$fieldFilter []= ['op' => '=', 'val' => $fieldValue];

--- a/plugin/Filter/FilterBuilderInputVariables.php
+++ b/plugin/Filter/FilterBuilderInputVariables.php
@@ -102,7 +102,9 @@ class FilterBuilderInputVariables
 	private function getFieldFilter($fieldValue, string $type): array
 	{
 		$fieldFilter = [];
-
+        if(is_string($fieldValue)){
+            $fieldValue = html_entity_decode($fieldValue);
+        }
 		if (FieldTypes::isNumericType($type) || FieldTypes::isDateOrDateTime($type)) {
 			if (!is_array($fieldValue)) {
 				$fieldFilter []= ['op' => '=', 'val' => $fieldValue];


### PR DESCRIPTION
Decodes a html string for filtering. In following case there is an issue when strings contain special characters like apostrophes, which are encoded as `&#039;` and is passed along to the oO API. For example if the user is searching for `Cortina d'Ampezzo`, the string is encoded to `Cortina d&#039;Ampezzo`. The API will not find any items because the string seems to not be decoded in the enterprise API.