### PR TITLE
Bug/P#125533-validator-field-type

### DIFF
--- a/plugin/Field/DefaultValue/ModelToOutputConverter/DefaultValueRowSaver.php
+++ b/plugin/Field/DefaultValue/ModelToOutputConverter/DefaultValueRowSaver.php
@@ -197,7 +197,7 @@ class DefaultValueRowSaver
 	 * @param mixed $values
 	 * @return mixed
 	 */
-	private function validateValues( $field, $values)
+	private function validateValues($field, $values)
 	{
 		if ($field === 'Email') {
 			if (is_array($values)) {

--- a/plugin/Field/DefaultValue/ModelToOutputConverter/DefaultValueRowSaver.php
+++ b/plugin/Field/DefaultValue/ModelToOutputConverter/DefaultValueRowSaver.php
@@ -193,11 +193,11 @@ class DefaultValueRowSaver
 	}
 
 	/**
-	 * @param string $field
+	 * @param string|int $field
 	 * @param mixed $values
 	 * @return mixed
 	 */
-	private function validateValues(string $field, $values)
+	private function validateValues( $field, $values)
 	{
 		if ($field === 'Email') {
 			if (is_array($values)) {


### PR DESCRIPTION
Removes a strict type checking on field names for the validator.
Sometimes it can be that fields have numeric field names instead of strings. In this case it could cause a crash. In some cases it can happen if a field has been deactivated in enterprise.