### PR TITLE
fix: replacement for filter_sanitize_string

### DIFF
--- a/plugin/FormPostHandler.php
+++ b/plugin/FormPostHandler.php
@@ -79,7 +79,7 @@ class FormPostHandler
 
 	static public function initialCheck()
 	{
-		$formName = filter_input(INPUT_POST, 'oo_formid', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+		$formName = RequestVariablesSanitizer::filterInputString(INPUT_POST, 'oo_formid');
 		$formNo = filter_input(INPUT_POST, 'oo_formno', FILTER_SANITIZE_NUMBER_INT);
 
 		if ($formName !== null && $formNo !== null) {

--- a/plugin/RequestVariablesSanitizer.php
+++ b/plugin/RequestVariablesSanitizer.php
@@ -72,7 +72,7 @@ class RequestVariablesSanitizer
 		$variable = stripslashes_deep($inputVariable[$name] ?? null);
 
 		if($filter == FILTER_SANITIZE_FULL_SPECIAL_CHARS){
-			return self::sanitizeFilterString($inputVariable[$name]);
+			return self::sanitizeFilterString($inputVariable[$name] ?? null);
 		}
 
 		return filter_var($variable, $filter, $option ?? 0);

--- a/plugin/RequestVariablesSanitizer.php
+++ b/plugin/RequestVariablesSanitizer.php
@@ -82,9 +82,13 @@ class RequestVariablesSanitizer
 		return self::sanitizeFilterString(filter_input($type, $var_name, FILTER_DEFAULT));
 	}
 
-	/**
-	 * Sanitize Strings based on the deprecated FILTER_SANITIZE_STRING filter.
-	 */
+    /**
+     * Sanitize Strings based on the deprecated FILTER_SANITIZE_STRING filter.
+     *
+     * @param $value
+     * @param array $flags
+     * @return string
+     */
 	public static function sanitizeFilterString($value, array $flags = []): string
 	{
 		$noQuotes = in_array(FILTER_FLAG_NO_ENCODE_QUOTES, $flags);

--- a/plugin/RequestVariablesSanitizer.php
+++ b/plugin/RequestVariablesSanitizer.php
@@ -70,6 +70,33 @@ class RequestVariablesSanitizer
 	private function getFiltered(array $inputVariable, string $name, int $filter, $option = null)
 	{
 		$variable = stripslashes_deep($inputVariable[$name] ?? null);
+
+		if($filter == FILTER_SANITIZE_FULL_SPECIAL_CHARS){
+			return self::sanitizeFilterString($inputVariable[$name]);
+		}
+
 		return filter_var($variable, $filter, $option ?? 0);
+	}
+
+	public static function filterInputString(int $type, string $var_name): string{
+		return self::sanitizeFilterString(filter_input($type, $var_name, FILTER_DEFAULT));
+	}
+
+	/**
+	 * Sanitize Strings based on the deprecated FILTER_SANITIZE_STRING filter.
+	 */
+	public static function sanitizeFilterString($value, array $flags = []): string
+	{
+		$noQuotes = in_array(FILTER_FLAG_NO_ENCODE_QUOTES, $flags);
+		$options = ($noQuotes ? ENT_NOQUOTES : ENT_QUOTES) | ENT_SUBSTITUTE;
+		$optionsDecode = ($noQuotes ? ENT_QUOTES : ENT_NOQUOTES) | ENT_SUBSTITUTE;
+
+		$value = stripslashes($value);
+		$value = strip_tags($value);
+		$value = htmlspecialchars($value, $options);
+
+		// Fix that HTML entities are converted to entity numbers instead of entity name (e.g. ' -> &#34; and not ' -> &quote;)
+		$value = str_replace(["&quot;", "&#039;"], ["&#34;", "&#39;"], $value);
+		return html_entity_decode($value, $optionsDecode);
 	}
 }

--- a/tests/TestClassRequestVariablesSanitizer.php
+++ b/tests/TestClassRequestVariablesSanitizer.php
@@ -70,11 +70,11 @@ class TestClassRequestVariablesSanitizer
 		$this->assertEquals('abc', $result);
 	}
 
-    /**
-     *
-     * @covers onOffice\WPlugin\RequestVariablesSanitizer::sanitizeFilterString
-     *
-     */
+	/**
+	 *
+	 * @covers onOffice\WPlugin\RequestVariablesSanitizer::sanitizeFilterString
+	 *
+	 */
 	public function testFilterInputString()
 	{
 		$value = RequestVariablesSanitizer::sanitizeFilterString('<b>abcßÖÄÜüöäüABC</b>');

--- a/tests/TestClassRequestVariablesSanitizer.php
+++ b/tests/TestClassRequestVariablesSanitizer.php
@@ -69,4 +69,22 @@ class TestClassRequestVariablesSanitizer
 
 		$this->assertEquals('abc', $result);
 	}
+
+    /**
+     *
+     * @covers onOffice\WPlugin\RequestVariablesSanitizer::sanitizeFilterString
+     *
+     */
+	public function testFilterInputString()
+	{
+        $value = RequestVariablesSanitizer::sanitizeFilterString('<b>abcßÖÄÜüöäüABC</b>');
+		$this->assertEquals('abcßÖÄÜüöäüABC', $value);
+
+        $value = RequestVariablesSanitizer::sanitizeFilterString('"');
+		$this->assertEquals('&#34;', $value);
+
+        $value = RequestVariablesSanitizer::sanitizeFilterString('\'');
+		$this->assertEquals('&#39;', $value);
+
+	}
 }

--- a/tests/TestClassRequestVariablesSanitizer.php
+++ b/tests/TestClassRequestVariablesSanitizer.php
@@ -77,13 +77,13 @@ class TestClassRequestVariablesSanitizer
      */
 	public function testFilterInputString()
 	{
-        $value = RequestVariablesSanitizer::sanitizeFilterString('<b>abcßÖÄÜüöäüABC</b>');
+		$value = RequestVariablesSanitizer::sanitizeFilterString('<b>abcßÖÄÜüöäüABC</b>');
 		$this->assertEquals('abcßÖÄÜüöäüABC', $value);
 
-        $value = RequestVariablesSanitizer::sanitizeFilterString('"');
+		$value = RequestVariablesSanitizer::sanitizeFilterString('"');
 		$this->assertEquals('&#34;', $value);
 
-        $value = RequestVariablesSanitizer::sanitizeFilterString('\'');
+		$value = RequestVariablesSanitizer::sanitizeFilterString('\'');
 		$this->assertEquals('&#39;', $value);
 
 	}


### PR DESCRIPTION
added a replacement for deprecated FILTER_SANITIZE_STRING filter because the new suggested FILTER_SANITIZE_FULL_SPECIAL_CHARS filter does not work as expected. PHP is also suggesting to use htmlspecialchars instead of FILTER_SANITIZE_STRING, but this will also not work as expected to our case.

I added this replacement and it is outputting the same value like with FILTER_SANITIZE_STRING.
Other solution would be to use FILTER_DEFAULT, but it will simply skip the filtering.