### PR TITLE
Bugfix/p#131303 critical error for inactive contact category field

### DIFF
--- a/plugin/Form/FormAddressCreator.php
+++ b/plugin/Form/FormAddressCreator.php
@@ -31,6 +31,8 @@ use onOffice\WPlugin\API\APIClientActionGeneric;
 use onOffice\WPlugin\API\ApiClientException;
 use onOffice\WPlugin\Cache\CacheHandler;
 use onOffice\WPlugin\DataFormConfiguration\DataFormConfiguration;
+use onOffice\WPlugin\Field\Collection\FieldLoaderGeneric;
+use onOffice\WPlugin\Field\Collection\FieldsCollectionBuilder;
 use onOffice\WPlugin\Field\Collection\FieldsCollectionBuilderShort;
 use onOffice\WPlugin\Field\UnknownFieldException;
 use onOffice\WPlugin\FormData;
@@ -82,6 +84,12 @@ class FormAddressCreator
 			$requestParams['noOverrideByDuplicate'] = true;
 		}
 
+		$addressFields = $this->getAddressFields();
+		if(!isset($addressFields['ArtDaten'])){
+			//Field is not active
+			$contactType = [];
+		}
+
 		if (!empty($contactType)) {
 			$requestParams['ArtDaten'] = $contactType;
 		}
@@ -110,6 +118,19 @@ class FormAddressCreator
 			return $addressId;
 		}
 		throw new ApiClientException($pApiClientAction);
+	}
+
+
+	/**
+	 * @return array
+	 * @throws DependencyException
+	 * @throws NotFoundException
+	 */
+	private function getAddressFields(): array
+	{
+		$pFieldsCollection = new FieldsCollection();
+		$this->_pFieldsCollectionBuilderShort->addFieldsAddressEstate($pFieldsCollection);
+		return $pFieldsCollection->getFieldsByModule('address');
 	}
 
 	/**

--- a/plugin/Model/FormModelBuilder/FormModelBuilderDBForm.php
+++ b/plugin/Model/FormModelBuilder/FormModelBuilderDBForm.php
@@ -463,13 +463,17 @@ class FormModelBuilderDBForm
         $field = $pInputModelFormContactType->getField();
         $pInputModelFormContactType->setHtmlType(InputModelOption::HTML_TYPE_SELECT_TWO);
         $availableContactType = $this->getDataContactType(onOfficeSDK::MODULE_ADDRESS);
-        $pInputModelFormContactType->setValuesAvailable($availableContactType);
-        $pInputModelFormContactType->setIsMulti(true);
-        $selectedValue = $this->getValue($field);
-        if (is_null($selectedValue)) {
-            $selectedValue = [];
-        }
-        $pInputModelFormContactType->setValue($selectedValue);
+        if($availableContactType === null){
+			$pInputModelFormContactType->setFieldInactive(true);
+		}else{
+			$pInputModelFormContactType->setValuesAvailable($availableContactType);
+			$pInputModelFormContactType->setIsMulti(true);
+			$selectedValue = $this->getValue($field);
+			if (is_null($selectedValue)) {
+				$selectedValue = [];
+			}
+			$pInputModelFormContactType->setValue($selectedValue);
+		}
 
         return $pInputModelFormContactType;
     }
@@ -482,6 +486,11 @@ class FormModelBuilderDBForm
                 ->buildFieldsCollection($pFieldLoader);
             $fields = $pFieldCollectionAddressEstate->getFieldsByModule($module);
             $result = [];
+
+			if(!isset($fields['ArtDaten'])) {
+				return null;
+			}
+
             if (!empty($fields['ArtDaten']->getPermittedvalues())) {
                 foreach ($fields['ArtDaten']->getPermittedvalues() as $field => $type) {
                     $result[$field] = !empty($type) ? $type: $field;

--- a/plugin/Model/InputModelBase.php
+++ b/plugin/Model/InputModelBase.php
@@ -107,6 +107,9 @@ abstract class InputModelBase
 	/** @var bool */
 	private $_deactivate = false;
 
+	/** @var bool */
+	private $_field_inactive = false;
+
 	/** @var string */
 	private $_label = null;
 
@@ -222,9 +225,16 @@ abstract class InputModelBase
 	public function setDeactivate($deactivate)
 		{ $this->_deactivate = $deactivate; }
 
+	/** @param bool $fieldInactive */
+	public function setFieldInactive($fieldInactive)
+	{ $this->_field_inactive = $fieldInactive; }
+
 	/** @return bool */
 	public function isDeactivate()
 		{ return $this->_deactivate; }
+
+	public function isFieldInactive()
+	{ return $this->_field_inactive; }
 
 	/** @return array */
 	public function getValuesAvailable()

--- a/plugin/Renderer/InputFieldRenderer.php
+++ b/plugin/Renderer/InputFieldRenderer.php
@@ -76,7 +76,10 @@ abstract class InputFieldRenderer
 
 	/** @var bool */
     private $_isDisabled = false;
-	
+
+	/** @var bool */
+	private $_isFieldInactive = false;
+
 	/**
 	 *
 	 * @param string $type
@@ -120,6 +123,17 @@ abstract class InputFieldRenderer
 		}
 	}
 
+	public function renderInactive()
+	{
+		$deactivatedInTheSoftware = ' ('.esc_html__('Disabled in onOffice', 'onoffice-for-wp-websites').')';
+		$disabledElement = <<<HTML
+			<span class="onoffice-field-inactive-text" style="color:red">
+				$deactivatedInTheSoftware
+			</span>
+HTML;
+
+		echo $disabledElement;
+	}
 
 	/**
 	 *
@@ -267,4 +281,13 @@ abstract class InputFieldRenderer
     /** @param bool $isDisabled */
     public function setIsDisabled(bool $isDisabled)
     { $this->_isDisabled = $isDisabled; }
+
+
+    /** @return bool */
+    public function getIsFieldInactive()
+    { return $this->_isFieldInactive; }
+
+    /** @param bool $isFieldInactive */
+    public function setIsFieldInactive(bool $isFieldInactive)
+    { $this->_isFieldInactive = $isFieldInactive; }
 }

--- a/plugin/Renderer/InputFieldSelectTwoRenderer.php
+++ b/plugin/Renderer/InputFieldSelectTwoRenderer.php
@@ -31,6 +31,12 @@ class InputFieldSelectTwoRenderer extends InputFieldSelectRenderer
 	 */
 	public function render()
 	{
+
+		if($this->getIsFieldInactive()){
+			$this->renderInactive();
+			return;
+		}
+
 		$name = $this->getMultiple() ? $this->getName() . '[]' : $this->getName();
 		$output = '<select name="'.esc_html($name).'"'
 					.$this->renderAdditionalAttributes()

--- a/plugin/Renderer/InputModelRenderer.php
+++ b/plugin/Renderer/InputModelRenderer.php
@@ -238,7 +238,11 @@ class InputModelRenderer
                 }
                 $pInstance->addAdditionalAttribute('class', $cssClasses);
                 $pInstance->setMultiple($isMultiple);
-				$pInstance->setSelectedValue($pInputModel->getValue());
+				$pInstance->setIsFieldInactive($pInputModel->isFieldInactive());
+
+				if(!$pInputModel->isFieldInactive()){
+					$pInstance->setSelectedValue($pInputModel->getValue());
+				}
 				break;
 
 			case InputModelOption::HTML_TYPE_NUMBER:

--- a/tests/TestClassFormAddressCreator.php
+++ b/tests/TestClassFormAddressCreator.php
@@ -115,6 +115,10 @@ class TestClassFormAddressCreator
 				$pField7->setLabel('newsletter');
 				$pFieldsCollection->addField($pField7);
 
+				$pFieldArtDaten = new Field('ArtDaten', onOfficeSDK::MODULE_ADDRESS);
+				$pFieldArtDaten->setType(FieldTypes::FIELD_TYPE_MULTISELECT);
+				$pFieldsCollection->addField($pFieldArtDaten);
+
 				return $this->_pFieldsCollectionBuilderShort;
 			}));
 	}

--- a/tests/TestClassFormPostContact.php
+++ b/tests/TestClassFormPostContact.php
@@ -137,6 +137,10 @@ class TestClassFormPostContact
 				$FieldTelefon1->setType(FieldTypes::FIELD_TYPE_VARCHAR);
 				$pFieldsCollection->addField($FieldTelefon1);
 
+				$pFieldArtDaten = new Field('ArtDaten', onOfficeSDK::MODULE_ADDRESS);
+				$pFieldArtDaten->setType(FieldTypes::FIELD_TYPE_MULTISELECT);
+				$pFieldsCollection->addField($pFieldArtDaten);
+
 				$pFieldAgbAkzeptiert = new Field('AGB_akzeptiert', onOfficeSDK::MODULE_ADDRESS);
 				$pFieldAgbAkzeptiert->setType(FieldTypes::FIELD_TYPE_BOOLEAN);
 				$pFieldsCollection->addField($pFieldAgbAkzeptiert);


### PR DESCRIPTION
Fixes a critical error in the administration for disabled contact category field in enterprise (The field is also called: 'ArtDaten' / 'HerkunftKontakt' / 'contactCategory' / 'Kontakt der neuen Adresse').

The input field in wp plugin can be found in the form administration on the in the top left box.

The field can be found here in enterprise: 
Extras -> Einstellungen -> Administration -> Eingabefelder. Modul: Adressverwaltung, Kategorie: Verwaltung, Feld: ArtDaten
To test it, you should clear the plugin cache after you changed the value in enterprise. 


This fix will show "Field inactive" warning in the plugin administration instead of critical error.