### PR TITLE
remove codewaehrung

### DIFF
--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -792,11 +792,6 @@ class EstateList
 		$this->_currentEstate['title'] = $currentRecord['elements']['objekttitel'] ?? '';
 
 		$recordModified = $pEstateFieldModifierHandler->processRecord($currentRecord['elements']);
-
-		$fieldWaehrung = $this->_pEnvironment->getFieldnames()->getFieldInformation('waehrung', onOfficeSDK::MODULE_ESTATE);
-		if (!empty($fieldWaehrung['permittedvalues']) && !empty($recordModified['waehrung']) && isset($recordModified['waehrung'])) {
-			$recordModified['codeWaehrung'] = array_search($recordModified['waehrung'], $fieldWaehrung['permittedvalues']);
-		}
 		$recordRaw = $this->_recordsRaw[$this->_currentEstate['id']]['elements'] ?? [];
 
 		if ($this->getShowEstateMarketingStatus()) {


### PR DESCRIPTION
Wenn das Währungsfeld auf der Detailseite verwendet wird, kommt es zu einer UnknownFieldException in /onoffice-for-wp-websites/plugin/Fieldnames.php:311 weil zwischenzeitlich ein Feld Names codewaehrung hinzugefügt wurde.

In Git Blame sieht es so aus als wäre diese Änderung mit dem neuen Cache in 6.0 hinzugekommen. Aber mit etwas Recherche bin ich auf ein PR aus 2023 gestoßen: 
https://github.com/onOffice-Web-Org/oo-wp-plugin/pull/105

Hier wurde die Änderung ursprünglich hinzugefügt.
Vor Version 6.0 wurde sie aber irgendwann wieder entfernt.
Ich nehme an, dass ein Merge Konflikt dafür gesorgt hat, dass der Code wieder in master gekommen ist.

Ich konnte sonst keine Stelle finden, die codeWaehrung nutzt und basierend auf den Titel des alten PR 2023 habe ich nochmal genau die Stellplätze angeschaut. Die sahen auch fehlerfrei aus.
