### PR TITLE
fix: incident/5827747-property-limit

### DIFF
--- a/plugin/Field/Collection/FieldLoaderEstateCityValues.php
+++ b/plugin/Field/Collection/FieldLoaderEstateCityValues.php
@@ -81,7 +81,7 @@ class FieldLoaderEstateCityValues
 	 * @return array
 	 * @throws ApiClientException
 	 */
-    
+
 	private function getListNameCity(): array
 	{
 		$requestParams = [

--- a/plugin/Field/Collection/FieldLoaderEstateCityValues.php
+++ b/plugin/Field/Collection/FieldLoaderEstateCityValues.php
@@ -98,7 +98,7 @@ class FieldLoaderEstateCityValues
 		$requestParams['filter']['veroeffentlichen'][] = ['op' => '=', 'val' => 1];
 
 		$pApiClientAction = new APIClientActionGeneric
-		($this->_pSDKWrapper, onOfficeSDK::ACTION_ID_READ, 'estate');
+		($this->_pSDKWrapper, onOfficeSDK::ACTION_ID_READ, onOfficeSDK::MODULE_ESTATE);
 		$pApiClientAction->setParameters($requestParams);
 		$pApiClientAction->addRequestToQueue()->sendRequests();
 		
@@ -113,7 +113,7 @@ class FieldLoaderEstateCityValues
 			$pageParams['listoffset'] = $offset;
 
 			$pPageAction = new APIClientActionGeneric
-			($this->_pSDKWrapper, onOfficeSDK::ACTION_ID_READ, 'estate');
+			($this->_pSDKWrapper, onOfficeSDK::ACTION_ID_READ, onOfficeSDK::MODULE_ESTATE);
 			$pPageAction->setParameters($pageParams);
 			$pPageAction->addRequestToQueue();
 			$additionalActions[] = $pPageAction;
@@ -121,9 +121,11 @@ class FieldLoaderEstateCityValues
 
 		if ($additionalActions !== []) {
 			$this->_pSDKWrapper->sendRequests();
+			$chunks = [$result];
 			foreach ($additionalActions as $pPageAction) {
-				$result = array_merge($result, $pPageAction->getResultRecords());
+				$chunks[] = $pPageAction->getResultRecords();
 			}
+			$result = array_merge(...$chunks);
 		}
 
 		if (empty($result)) {

--- a/plugin/Field/Collection/FieldLoaderEstateCityValues.php
+++ b/plugin/Field/Collection/FieldLoaderEstateCityValues.php
@@ -78,49 +78,73 @@ class FieldLoaderEstateCityValues
 
 
 	/**
-	 * @return array
-	 * @throws ApiClientException
-	 */
+     * @return array
+     * @throws ApiClientException
+     */
+    private function getListNameCity(): array
+    {
+        $requestParams = [
+            'data' => ['ort'],
+            'listlimit' => 500,
+            'estatelanguage' => Language::getDefault(),
+        ];
 
-	private function getListNameCity(): array
-	{
-		$requestParams = [
-			'data' => ['ort'],
-			'listlimit' => 500,
-			'estatelanguage' => Language::getDefault(),
-		];
+        if ($this->_pShowReferenceEstate === DataListView::HIDE_REFERENCE_ESTATE) {
+            $requestParams['filter']['referenz'][] = ['op' => '=', 'val' => 0];
+        } elseif ($this->_pShowReferenceEstate === DataListView::SHOW_ONLY_REFERENCE_ESTATE) {
+            $requestParams['filter']['referenz'][] = ['op' => '=', 'val' => 1];
+        }
+        $requestParams['filter']['veroeffentlichen'][] = ['op' => '=', 'val' => 1];
 
-		if ($this->_pShowReferenceEstate === DataListView::HIDE_REFERENCE_ESTATE) {
-			$requestParams['filter']['referenz'][] = ['op' => '=', 'val' => 0];
-		} elseif ($this->_pShowReferenceEstate === DataListView::SHOW_ONLY_REFERENCE_ESTATE) {
-			$requestParams['filter']['referenz'][] = ['op' => '=', 'val' => 1];
-		}
-		$requestParams['filter']['veroeffentlichen'][] = ['op' => '=', 'val' => 1];
+        $pApiClientAction = new APIClientActionGeneric
+        ($this->_pSDKWrapper, onOfficeSDK::ACTION_ID_READ, 'estate');
+        $pApiClientAction->setParameters($requestParams);
+        $pApiClientAction->addRequestToQueue()->sendRequests();
+        
+        $result = $pApiClientAction->getResultRecords();
+        $meta = $pApiClientAction->getResultMeta();
+        $totalRecords = (int)($meta['cntabsolute'] ?? count($result));
 
-		$pApiClientAction = new APIClientActionGeneric
-		($this->_pSDKWrapper, onOfficeSDK::ACTION_ID_READ, 'estate');
-		$pApiClientAction->setParameters($requestParams);
-		$pApiClientAction->addRequestToQueue()->sendRequests();
-		$result = $pApiClientAction->getResultRecords();
+        // Fetch remaining pages if total records exceed the 500 listlimit
+        $additionalActions = [];
+        for ($offset = 500; $offset < $totalRecords; $offset += 500) {
+            $pageParams = $requestParams;
+            $pageParams['listoffset'] = $offset;
 
-		if (empty($result)) {
-			return [];
-		}
+            $pPageAction = new APIClientActionGeneric
+            ($this->_pSDKWrapper, onOfficeSDK::ACTION_ID_READ, 'estate');
+            $pPageAction->setParameters($pageParams);
+            $pPageAction->addRequestToQueue();
+            $additionalActions[] = $pPageAction;
+        }
 
-		$listCityName = [];
-		foreach ($result as $value) {
-			if(!empty($value['elements']['ort'])){
-				$listCityName[] = $value['elements']['ort'];
-			}
-		}
+        if ($additionalActions !== []) {
+            $this->_pSDKWrapper->sendRequests();
+            foreach ($additionalActions as $pPageAction) {
+                $result = array_merge($result, $pPageAction->getResultRecords());
+            }
+        }
 
-		if (empty($listCityName)) {
-			return [];
-		}
-		sort($listCityName);
+        if (empty($result)) {
+            return [];
+        }
 
-		return array_unique($listCityName);
-	}
+        $listCityName = [];
+        foreach ($result as $value) {
+            if (!empty($value['elements']['ort'])) {
+                $listCityName[] = $value['elements']['ort'];
+            }
+        }
+
+        if (empty($listCityName)) {
+            return [];
+        }
+        
+        $listCityName = array_unique($listCityName);
+        sort($listCityName);
+
+        return array_values($listCityName);
+    }
 
 
 	/**

--- a/plugin/Field/Collection/FieldLoaderEstateCityValues.php
+++ b/plugin/Field/Collection/FieldLoaderEstateCityValues.php
@@ -78,73 +78,73 @@ class FieldLoaderEstateCityValues
 
 
 	/**
-     * @return array
-     * @throws ApiClientException
-     */
-    private function getListNameCity(): array
-    {
-        $requestParams = [
-            'data' => ['ort'],
-            'listlimit' => 500,
-            'estatelanguage' => Language::getDefault(),
-        ];
+	 * @return array
+	 * @throws ApiClientException
+	 */
+	private function getListNameCity(): array
+	{
+		$requestParams = [
+			'data' => ['ort'],
+			'listlimit' => 500,
+			'estatelanguage' => Language::getDefault(),
+		];
 
-        if ($this->_pShowReferenceEstate === DataListView::HIDE_REFERENCE_ESTATE) {
-            $requestParams['filter']['referenz'][] = ['op' => '=', 'val' => 0];
-        } elseif ($this->_pShowReferenceEstate === DataListView::SHOW_ONLY_REFERENCE_ESTATE) {
-            $requestParams['filter']['referenz'][] = ['op' => '=', 'val' => 1];
-        }
-        $requestParams['filter']['veroeffentlichen'][] = ['op' => '=', 'val' => 1];
+		if ($this->_pShowReferenceEstate === DataListView::HIDE_REFERENCE_ESTATE) {
+			$requestParams['filter']['referenz'][] = ['op' => '=', 'val' => 0];
+		} elseif ($this->_pShowReferenceEstate === DataListView::SHOW_ONLY_REFERENCE_ESTATE) {
+			$requestParams['filter']['referenz'][] = ['op' => '=', 'val' => 1];
+		}
+		$requestParams['filter']['veroeffentlichen'][] = ['op' => '=', 'val' => 1];
 
-        $pApiClientAction = new APIClientActionGeneric
-        ($this->_pSDKWrapper, onOfficeSDK::ACTION_ID_READ, 'estate');
-        $pApiClientAction->setParameters($requestParams);
-        $pApiClientAction->addRequestToQueue()->sendRequests();
-        
-        $result = $pApiClientAction->getResultRecords();
-        $meta = $pApiClientAction->getResultMeta();
-        $totalRecords = (int)($meta['cntabsolute'] ?? count($result));
+		$pApiClientAction = new APIClientActionGeneric
+		($this->_pSDKWrapper, onOfficeSDK::ACTION_ID_READ, 'estate');
+		$pApiClientAction->setParameters($requestParams);
+		$pApiClientAction->addRequestToQueue()->sendRequests();
+		
+		$result = $pApiClientAction->getResultRecords();
+		$meta = $pApiClientAction->getResultMeta();
+		$totalRecords = (int)($meta['cntabsolute'] ?? count($result));
 
-        // Fetch remaining pages if total records exceed the 500 listlimit
-        $additionalActions = [];
-        for ($offset = 500; $offset < $totalRecords; $offset += 500) {
-            $pageParams = $requestParams;
-            $pageParams['listoffset'] = $offset;
+		// Fetch remaining pages if total records exceed the 500 listlimit
+		$additionalActions = [];
+		for ($offset = 500; $offset < $totalRecords; $offset += 500) {
+			$pageParams = $requestParams;
+			$pageParams['listoffset'] = $offset;
 
-            $pPageAction = new APIClientActionGeneric
-            ($this->_pSDKWrapper, onOfficeSDK::ACTION_ID_READ, 'estate');
-            $pPageAction->setParameters($pageParams);
-            $pPageAction->addRequestToQueue();
-            $additionalActions[] = $pPageAction;
-        }
+			$pPageAction = new APIClientActionGeneric
+			($this->_pSDKWrapper, onOfficeSDK::ACTION_ID_READ, 'estate');
+			$pPageAction->setParameters($pageParams);
+			$pPageAction->addRequestToQueue();
+			$additionalActions[] = $pPageAction;
+		}
 
-        if ($additionalActions !== []) {
-            $this->_pSDKWrapper->sendRequests();
-            foreach ($additionalActions as $pPageAction) {
-                $result = array_merge($result, $pPageAction->getResultRecords());
-            }
-        }
+		if ($additionalActions !== []) {
+			$this->_pSDKWrapper->sendRequests();
+			foreach ($additionalActions as $pPageAction) {
+				$result = array_merge($result, $pPageAction->getResultRecords());
+			}
+		}
 
-        if (empty($result)) {
-            return [];
-        }
+		if (empty($result)) {
+			return [];
+		}
 
-        $listCityName = [];
-        foreach ($result as $value) {
-            if (!empty($value['elements']['ort'])) {
-                $listCityName[] = $value['elements']['ort'];
-            }
-        }
+		$listCityName = [];
+		foreach ($result as $value) {
+			if (!empty($value['elements']['ort'])) {
+				$listCityName[] = $value['elements']['ort'];
+			}
+		}
 
-        if (empty($listCityName)) {
-            return [];
-        }
-        
-        $listCityName = array_unique($listCityName);
-        sort($listCityName);
+		if (empty($listCityName)) {
+			return [];
+		}
+		
+		$listCityName = array_unique($listCityName);
+		sort($listCityName);
 
-        return array_values($listCityName);
-    }
+		return array_values($listCityName);
+	}
 
 
 	/**

--- a/plugin/Field/Collection/FieldLoaderEstateCityValues.php
+++ b/plugin/Field/Collection/FieldLoaderEstateCityValues.php
@@ -81,6 +81,7 @@ class FieldLoaderEstateCityValues
 	 * @return array
 	 * @throws ApiClientException
 	 */
+    
 	private function getListNameCity(): array
 	{
 		$requestParams = [

--- a/tests/TestClassFieldLoaderEstateCityValues.php
+++ b/tests/TestClassFieldLoaderEstateCityValues.php
@@ -174,92 +174,92 @@ class TestClassFieldLoaderEstateCityValues
 	}
 
 	/**
-     * Tests the pagination loop when the API returns more than 500 records.
-     */
-    public function testLoadWithPagination()
-    {
-        $fieldParameters = [
-            'labels' => true,
-            'showContent' => true,
-            'showTable' => true,
-            'fieldList' => ['ort'],
-            'language' => Language::getDefault(),
-            'modules' => [onOfficeSDK::MODULE_ESTATE],
-            'realDataTypes' => true
-        ];
+	 * Tests the pagination loop when the API returns more than 500 records.
+	 */
+	public function testLoadWithPagination()
+	{
+		$fieldParameters = [
+			'labels' => true,
+			'showContent' => true,
+			'showTable' => true,
+			'fieldList' => ['ort'],
+			'language' => Language::getDefault(),
+			'modules' => [onOfficeSDK::MODULE_ESTATE],
+			'realDataTypes' => true
+		];
 
-        $estateParameters = [
-            'data' => ['ort'],
-            'listlimit' => 500,
-            'estatelanguage' => Language::getDefault(),
-            'filter' => [
-                'referenz' => [['op' => '=', 'val' => 1]],
-                'veroeffentlichen' => [['op' => '=', 'val' => 1]]
-            ]
-        ];
+		$estateParameters = [
+			'data' => ['ort'],
+			'listlimit' => 500,
+			'estatelanguage' => Language::getDefault(),
+			'filter' => [
+				'referenz' => [['op' => '=', 'val' => 1]],
+				'veroeffentlichen' => [['op' => '=', 'val' => 1]]
+			]
+		];
 
-        $pSDKWrapper = new SDKWrapperMocker();
+		$pSDKWrapper = new SDKWrapperMocker();
 
-        // Mock Fields Request
-        $pSDKWrapper->addResponseByParameters(onOfficeSDK::ACTION_ID_GET, 'fields', '',
-            $fieldParameters, null, $this->responseField);
+		// Mock Fields Request
+		$pSDKWrapper->addResponseByParameters(onOfficeSDK::ACTION_ID_GET, 'fields', '',
+			$fieldParameters, null, $this->responseField);
 
-        // Mock Page 1 (Offset 0, Records 1-500)
-        $pSDKWrapper->addResponseByParameters(onOfficeSDK::ACTION_ID_READ, 'estate', '',
-            $estateParameters, null, $this->buildEstateResponse(501, 'Aachen'));
+		// Mock Page 1 (Offset 0, Records 1-500)
+		$pSDKWrapper->addResponseByParameters(onOfficeSDK::ACTION_ID_READ, 'estate', '',
+			$estateParameters, null, $this->buildEstateResponse(501, 'Aachen'));
 
-        // Mock Page 2 (Offset 500, Records 501-1000)
-        $page2Params = $estateParameters;
-        $page2Params['listoffset'] = 500;
-        $pSDKWrapper->addResponseByParameters(onOfficeSDK::ACTION_ID_READ, 'estate', '',
-            $page2Params, null, $this->buildEstateResponse(501, 'Zwickau'));
+		// Mock Page 2 (Offset 500, Records 501-1000)
+		$page2Params = $estateParameters;
+		$page2Params['listoffset'] = 500;
+		$pSDKWrapper->addResponseByParameters(onOfficeSDK::ACTION_ID_READ, 'estate', '',
+			$page2Params, null, $this->buildEstateResponse(501, 'Zwickau'));
 
-        $pContainerBuilder = new ContainerBuilder;
-        $pContainerBuilder->addDefinitions(ONOFFICE_DI_CONFIG_PATH);
-        $pContainer = $pContainerBuilder->build();
-        $pContainer->set(SDKWrapper::class, $pSDKWrapper);
-        
-        $pFieldLoader = $pContainer->make(FieldLoaderEstateCityValues::class, ['pShowReferenceEstate' => '2']);
+		$pContainerBuilder = new ContainerBuilder;
+		$pContainerBuilder->addDefinitions(ONOFFICE_DI_CONFIG_PATH);
+		$pContainer = $pContainerBuilder->build();
+		$pContainer->set(SDKWrapper::class, $pSDKWrapper);
+		
+		$pFieldLoader = $pContainer->make(FieldLoaderEstateCityValues::class, ['pShowReferenceEstate' => '2']);
 
-        $result = iterator_to_array($pFieldLoader->load());
+		$result = iterator_to_array($pFieldLoader->load());
 
-        // The loader must successfully query both pages, extract the cities, merge, sort, and deduplicate them.
-        $this->assertEquals(['Aachen', 'Zwickau'], $result['ort']['permittedvalues']);
-    }
+		// The loader must successfully query both pages, extract the cities, merge, sort, and deduplicate them.
+		$this->assertEquals(['Aachen', 'Zwickau'], $result['ort']['permittedvalues']);
+	}
 
-    /**
-     * Helper method to generate mock estate responses with dynamic metadata.
-     * 
-     * @param int $cntabsolute
-     * @param string $cityName
-     * @return array
-     */
-    private function buildEstateResponse(int $cntabsolute, string $cityName): array
-    {
-        return [
-            "actionid" => "urn:onoffice-de-ns:smart:2.5:smartml:action:read",
-            "resourceid" => "",
-            "resourcetype" => "estate",
-            "cacheable" => true,
-            "identifier" => "",
-            "data" => [
-                "meta" => [
-                    "cntabsolute" => $cntabsolute
-                ],
-                "records" => [
-                    [
-                        "id" => "1",
-                        "type" => "",
-                        "elements" => [
-                            "ort" => $cityName
-                        ]
-                    ]
-                ]
-            ],
-            "status" => [
-                "errorcode" => 0,
-                "message" => "OK"
-            ]
-        ];
-    }
+	/**
+	 * Helper method to generate mock estate responses with dynamic metadata.
+	 * 
+	 * @param int $cntabsolute
+	 * @param string $cityName
+	 * @return array
+	 */
+	private function buildEstateResponse(int $cntabsolute, string $cityName): array
+	{
+		return [
+			"actionid" => "urn:onoffice-de-ns:smart:2.5:smartml:action:read",
+			"resourceid" => "",
+			"resourcetype" => "estate",
+			"cacheable" => true,
+			"identifier" => "",
+			"data" => [
+				"meta" => [
+					"cntabsolute" => $cntabsolute
+				],
+				"records" => [
+					[
+						"id" => "1",
+						"type" => "",
+						"elements" => [
+							"ort" => $cityName
+						]
+					]
+				]
+			],
+			"status" => [
+				"errorcode" => 0,
+				"message" => "OK"
+			]
+		];
+	}
 }

--- a/tests/TestClassFieldLoaderEstateCityValues.php
+++ b/tests/TestClassFieldLoaderEstateCityValues.php
@@ -205,13 +205,13 @@ class TestClassFieldLoaderEstateCityValues
 			$fieldParameters, null, $this->responseField);
 
 		// Mock Page 1 (Offset 0, Records 1-500)
-		$pSDKWrapper->addResponseByParameters(onOfficeSDK::ACTION_ID_READ, 'estate', '',
+		$pSDKWrapper->addResponseByParameters(onOfficeSDK::ACTION_ID_READ, onOfficeSDK::MODULE_ESTATE, '',
 			$estateParameters, null, $this->buildEstateResponse(501, 'Aachen'));
 
 		// Mock Page 2 (Offset 500, Records 501-1000)
 		$page2Params = $estateParameters;
 		$page2Params['listoffset'] = 500;
-		$pSDKWrapper->addResponseByParameters(onOfficeSDK::ACTION_ID_READ, 'estate', '',
+		$pSDKWrapper->addResponseByParameters(onOfficeSDK::ACTION_ID_READ, onOfficeSDK::MODULE_ESTATE, '',
 			$page2Params, null, $this->buildEstateResponse(501, 'Zwickau'));
 
 		$pContainerBuilder = new ContainerBuilder;

--- a/tests/TestClassFieldLoaderEstateCityValues.php
+++ b/tests/TestClassFieldLoaderEstateCityValues.php
@@ -172,4 +172,94 @@ class TestClassFieldLoaderEstateCityValues
 		];
 		$this->assertEquals($expectation, $result);
 	}
+
+	/**
+     * Tests the pagination loop when the API returns more than 500 records.
+     */
+    public function testLoadWithPagination()
+    {
+        $fieldParameters = [
+            'labels' => true,
+            'showContent' => true,
+            'showTable' => true,
+            'fieldList' => ['ort'],
+            'language' => Language::getDefault(),
+            'modules' => [onOfficeSDK::MODULE_ESTATE],
+            'realDataTypes' => true
+        ];
+
+        $estateParameters = [
+            'data' => ['ort'],
+            'listlimit' => 500,
+            'estatelanguage' => Language::getDefault(),
+            'filter' => [
+                'referenz' => [['op' => '=', 'val' => 1]],
+                'veroeffentlichen' => [['op' => '=', 'val' => 1]]
+            ]
+        ];
+
+        $pSDKWrapper = new SDKWrapperMocker();
+
+        // Mock Fields Request
+        $pSDKWrapper->addResponseByParameters(onOfficeSDK::ACTION_ID_GET, 'fields', '',
+            $fieldParameters, null, $this->responseField);
+
+        // Mock Page 1 (Offset 0, Records 1-500)
+        $pSDKWrapper->addResponseByParameters(onOfficeSDK::ACTION_ID_READ, 'estate', '',
+            $estateParameters, null, $this->buildEstateResponse(501, 'Aachen'));
+
+        // Mock Page 2 (Offset 500, Records 501-1000)
+        $page2Params = $estateParameters;
+        $page2Params['listoffset'] = 500;
+        $pSDKWrapper->addResponseByParameters(onOfficeSDK::ACTION_ID_READ, 'estate', '',
+            $page2Params, null, $this->buildEstateResponse(501, 'Zwickau'));
+
+        $pContainerBuilder = new ContainerBuilder;
+        $pContainerBuilder->addDefinitions(ONOFFICE_DI_CONFIG_PATH);
+        $pContainer = $pContainerBuilder->build();
+        $pContainer->set(SDKWrapper::class, $pSDKWrapper);
+        
+        $pFieldLoader = $pContainer->make(FieldLoaderEstateCityValues::class, ['pShowReferenceEstate' => '2']);
+
+        $result = iterator_to_array($pFieldLoader->load());
+
+        // The loader must successfully query both pages, extract the cities, merge, sort, and deduplicate them.
+        $this->assertEquals(['Aachen', 'Zwickau'], $result['ort']['permittedvalues']);
+    }
+
+    /**
+     * Helper method to generate mock estate responses with dynamic metadata.
+     * 
+     * @param int $cntabsolute
+     * @param string $cityName
+     * @return array
+     */
+    private function buildEstateResponse(int $cntabsolute, string $cityName): array
+    {
+        return [
+            "actionid" => "urn:onoffice-de-ns:smart:2.5:smartml:action:read",
+            "resourceid" => "",
+            "resourcetype" => "estate",
+            "cacheable" => true,
+            "identifier" => "",
+            "data" => [
+                "meta" => [
+                    "cntabsolute" => $cntabsolute
+                ],
+                "records" => [
+                    [
+                        "id" => "1",
+                        "type" => "",
+                        "elements" => [
+                            "ort" => $cityName
+                        ]
+                    ]
+                ]
+            ],
+            "status" => [
+                "errorcode" => 0,
+                "message" => "OK"
+            ]
+        ];
+    }
 }


### PR DESCRIPTION
### TL;DR
Das gemeldete Fehlen von „Aichhalden“ ist ein Datenkonfigurationsfehler (die Immobilie ist nicht veröffentlicht), kein Fehler im Code. Trotzdem könnte bei 500+ Immobilien tatsächlich  der beschriebene Fehler auftreten, also ein möglicher Limitierungsfehler im Plugin. Die Generierung des Orts Dropdowns war auf 500 Datensätze begrenzt. Dieser PR implementiert eine Paginationschleife in `FieldLoaderEstateCityValues`, um große Datensätze in Batches zu verarbeiten. Dadurch wird sichergestellt, dass alle Orte unabhängig von der Anzahl der Immobilien extrahiert werden.

### Problem
**1. "Aichhalden" (Datenkonfiguration)**
Die spezifische Immobilie in Aichhalden ist nicht veröffentlicht und auch keine Referenz.

**2. API-Limitierung**
Der Kunde verfügt über 1000 Referenzen. Die Class `FieldLoaderEstateCityValues` führte bisher einen einzigen API-Request mit listlimit = 500 und ohne listoffset aus. Folglich wird jeder Ort, der ausschließlich Immobilien ab Index 501 zugeordnet ist, permanent aus dem ort-Dropdown abgeschnitten.

**Reproduktion im master**
Da wir im onmove Broker nur ca. 30 veröffentlichte Immobilien haben, hab ich das Listlimit temporär auf 20 geschaltet und dann nach meiner neu angelegten Immobilie in Kiel gesucht (ObjektNr: 1485). Unter den ersten 20 Immobilien befindet sich keine Immobilie in Kiel, daher wird der neue Ort im Dropdown auch nicht übernommen.
<img width="2460" height="1019" alt="image" src="https://github.com/user-attachments/assets/2c719da5-6701-4805-b4a8-b4b8fcb4a45e" />


**Verifizierung des Fixes / Branch**
Temporär sowohl das listlimit als auch das $offset auf 20 setzen. Kiel sollte jetzt wieder vorhanden sein, obwohl es über dem 20 Limit liegt.
<img width="1290" height="1170" alt="image" src="https://github.com/user-attachments/assets/0a1f9643-3d4c-4af2-abc5-1bb54ad247e4" />

### Lösung
Überschreitet die Gesamtzahl der Datensätze (`$totalRecords`) das listlimit von 500, reiht eine Schleife weitere Requests mit listoffset 500 in die Warteschlange ein. Der SDKWrapper verarbeitet alle in der Warteschlange befindlichen Requests in einer einzigen gebündelten HTTP-Transaktion, um die Performance zu maximieren.
Die zurückgegebenen Datensätze werden im Speicher zusammengeführt, woraufhin die eindeutigen Ortsnamen extrahiert, dedupliziert und sortiert werden.

**Note:**
`FieldLoaderAddressCityValues.php` hat dasselbe Limitierungsproblem. Ggf. könnte ich das auch hier mit fixen oder vielleicht lieber in einem separaten Projekt?