### PR TITLE
refactor(P#169523): WP-Plugin: Log Warnings

### DIFF
--- a/plugin/Controller/ContentFilter/ContentFilterShortCodeEstateDetail.php
+++ b/plugin/Controller/ContentFilter/ContentFilterShortCodeEstateDetail.php
@@ -96,10 +96,18 @@ class ContentFilterShortCodeEstateDetail
 	public function renderHtmlHelperUserIfEmptyEstateId(): string
 	{
 		$pDataDetail = $this->getRandomEstateDetail();
-		$itemTitle = empty($pDataDetail['elements']["objekttitel"]) ? __('Example estate', 'onoffice-for-wp-websites') : $pDataDetail['elements']["objekttitel"];
 		$type = __('estate', 'onoffice-for-wp-websites');
 		$documentLink = __('https://wp-plugin.onoffice.com/en/first-steps/estate-lists/', 'onoffice-for-wp-websites');
-		$linkDetail = '<a class="oo-detailview-helper-link" href=' . $this->getEstateLink($pDataDetail) . '>' . $itemTitle . '</a>';
+		$linkDetail = '';
+
+		// getRandomEstateDetail() returns [] when the API has no published, non-reference estate
+		// to preview. RenderHtmlHelperUsers falls back to the documentation link in that case and
+		// discards $linkDetail, so the preview link is only built for a record that exists.
+		if (!empty($pDataDetail)) {
+			$itemTitle = empty($pDataDetail['elements']["objekttitel"]) ? __('Example estate', 'onoffice-for-wp-websites') : $pDataDetail['elements']["objekttitel"];
+			$linkDetail = '<a class="oo-detailview-helper-link" href=' . $this->getEstateLink($pDataDetail) . '>' . $itemTitle . '</a>';
+		}
+
 		return RenderHtmlHelperUsers::renderHtmlHelperUserIfEmptyId($type, $documentLink, $linkDetail, $pDataDetail);
 	}
 
@@ -168,19 +176,22 @@ class ContentFilterShortCodeEstateDetail
 	 */
 	public function getEstateLink( $pEstateListDetail ): string
 	{
-		$pLanguageSwitcher = new EstateDetailUrl;
-		$pageId            = $pEstateListDetail['elements']['mainLangId'] ?? $pEstateListDetail['id'];
-		$fullLink          = '#';
+		// Both keys are absent for an empty record, so the fallback needs its own default -
+		// '??' only guards its left-hand operand, not $pEstateListDetail['id'].
+		$estateId = (int) ( $pEstateListDetail['elements']['mainLangId'] ?? $pEstateListDetail['id'] ?? 0 );
 
-		if ( $pageId !== 0 ) {
-			$estate           = $pEstateListDetail['elements']['mainLangId'] ?? $pEstateListDetail['id'];
-			$title            = $pEstateListDetail['elements']['objekttitel'] ?? '';
-			$url              = $this->getPageLink();
-			$fullLink         = $pLanguageSwitcher->createEstateDetailLink( $url, (int) $estate, $title );
-			$fullLinkElements = wp_parse_url($fullLink);
-			if ( empty( $fullLinkElements['query'] ) ) {
-				$fullLink .= '/';
-			}
+		if ( $estateId === 0 ) {
+			return '#';
+		}
+
+		$pLanguageSwitcher = new EstateDetailUrl;
+		$title             = $pEstateListDetail['elements']['objekttitel'] ?? '';
+		$url               = $this->getPageLink();
+		$fullLink          = $pLanguageSwitcher->createEstateDetailLink( $url, $estateId, $title );
+		$fullLinkElements  = wp_parse_url( $fullLink );
+
+		if ( empty( $fullLinkElements['query'] ) ) {
+			$fullLink .= '/';
 		}
 
 		return $fullLink;

--- a/plugin/DataView/DataDetailViewCheckAccessControl.php
+++ b/plugin/DataView/DataDetailViewCheckAccessControl.php
@@ -64,20 +64,22 @@ class DataDetailViewCheckAccessControl
 
 	public function checkRestrictAccess( int $estateId ): bool
 	{
-		$restrictAccess = $this->pDataDetailViewHandler->getDetailView()->getViewRestrict();
-
-		if ( $restrictAccess ) {
-			$pEstateDetail = $this->estateListFactory->createEstateDetail( $estateId );
-			$pEstateDetail->loadEstates();
-			$pEstateDetail->estateIterator();
-			$rawValues = $pEstateDetail->getRawValues();
-			$referenz  = $rawValues->getValueRaw( $estateId )['elements']['referenz'];
-
-			if ( $referenz === "1" ) {
-				return true;
-			}
+		if ( ! $this->pDataDetailViewHandler->getDetailView()->getViewRestrict() ) {
+			return false;
 		}
 
-		return false;
+		$pEstateDetail = $this->estateListFactory->createEstateDetail( $estateId );
+		$pEstateDetail->loadEstates();
+		$pEstateDetail->estateIterator();
+
+		// ArrayContainer::getValueRaw() returns null for every estate the API did not return:
+		// an unknown or unpublished ID, and - because getViewRestrict() also adds
+		// filter[referenz]=0 in EstateList::getEstateParameters() - a reference estate as well.
+		// Those requests are turned into a 404 by EstateIdRequestGuard::isValid() in plugin.php,
+		// so "no record" must not be reported as restricted here.
+		$estateRawValues = $pEstateDetail->getRawValues()->getValueRaw( $estateId );
+		$referenz        = $estateRawValues['elements']['referenz'] ?? null;
+
+		return $referenz === "1";
 	}
 }


### PR DESCRIPTION
DataDetailViewCheckAccessControl.php (Zeile 74)

Ursache: getValueRaw() liefert null, wenn die API keinen Datensatz zurückgibt → null['elements']['referenz']
Fix: ?? null beim Auslesen, Guard-Clause statt Verschachtelung, Kommentar warum „kein Datensatz" ≠ „gesperrt"
Verhalten unverändert (null === "1" war schon vorher false)

ContentFilterShortCodeEstateDetail.php (Zeilen 172/176)

Ursache: ?? schützt nur den linken Operanden — der Fallback ['id'] war ungeschützt; bei leerem Datensatz zweimal getroffen
Fix 1: Link nur noch bauen, wenn ein Datensatz existiert (RenderHtmlHelperUsers verwarf ihn bei leerem Array ohnehin)
Fix 2: doppelte ID-Ermittlung zu einer Zeile mit eigenem Default zusammengezogen (?? ... ?? 0), '#'-Fallback funktioniert jetzt wirklich (vorher wurde String-ID gegen int 0 verglichen → immer true)