### PR TITLE
fix: clear the cache on demand and cache searched estate lists

### DIFF
--- a/SDK/src/internal/ApiCall.php
+++ b/SDK/src/internal/ApiCall.php
@@ -225,11 +225,27 @@ class ApiCall
 			);
 			$params = $usedParameters["parameters"];
 
-			// 1. Check in-memory cache first (catches ALL duplicate calls within this PHP request)
-			$inMemoryKey = $this->getInMemoryCacheKey($usedParameters);
-			if (isset(self::$_inMemoryCache[$inMemoryKey]))
+			// params_list_cache holds the parameters the cron warmed the list under:
+			// same list, default filter, complete record set. Look the cache up under
+			// those, so a request with an active search hits the entry at all, and let
+			// applyListCacheFiltering() below trim the full set to this page.
+			$cacheParameters = $usedParameters;
+			if (isset($params['params_list_cache']) && is_array($params['params_list_cache']))
 			{
-				$inMemoryResponse = self::$_inMemoryCache[$inMemoryKey];
+				$cacheParameters['parameters'] = $params['params_list_cache'];
+			}
+
+			// $cacheKey is shared by every page and search of one list, $requestKey is not.
+			// Duplicate detection must use $requestKey: keyed by $cacheKey, two different
+			// searches on the same list look like duplicates and the second one gets the
+			// first one's records. See TestClassApiCall.
+			$cacheKey = $this->getInMemoryCacheKey($cacheParameters);
+			$requestKey = $this->getInMemoryCacheKey($usedParameters);
+
+			// 1. Check in-memory cache first (catches ALL duplicate calls within this PHP request)
+			if (isset(self::$_inMemoryCache[$cacheKey]))
+			{
+				$inMemoryResponse = self::$_inMemoryCache[$cacheKey];
 				// Apply list-specific filtering/sorting if needed (same logic as DB cache hit)
 				if (isset($params['listname']))
 				{
@@ -239,14 +255,21 @@ class ApiCall
 				continue;
 			}
 
+			// Exact response for this request, stored after an HTTP fetch below - already trimmed.
+			if ($cacheKey !== $requestKey && isset(self::$_inMemoryCache[$requestKey]))
+			{
+				$this->_responses[$requestId] = new Response($pRequest, self::$_inMemoryCache[$requestKey]);
+				continue;
+			}
+
 			// 2. Check DB cache (existing logic for list-based caching)
-			$cachedResponse = $this->getFromCache($usedParameters);
+			$cachedResponse = $this->getFromCache($cacheParameters);
 
 			if ($cachedResponse === null)
 			{
-				if (isset($sourceRequestIdByCacheKey[$inMemoryKey]))
+				if (isset($sourceRequestIdByCacheKey[$requestKey]))
 				{
-					$sourceRequestId = $sourceRequestIdByCacheKey[$inMemoryKey];
+					$sourceRequestId = $sourceRequestIdByCacheKey[$requestKey];
 					if (!isset($duplicateRequestsBySourceRequestId[$sourceRequestId]))
 					{
 						$duplicateRequestsBySourceRequestId[$sourceRequestId] = array();
@@ -268,12 +291,12 @@ class ApiCall
 
 				$actionParameters[] = $parametersThisAction;
 				$actionParametersOrder[] = $pRequest;
-				$sourceRequestIdByCacheKey[$inMemoryKey] = $requestId;
+				$sourceRequestIdByCacheKey[$requestKey] = $requestId;
 			}
 			else
 			{
-				// Store in in-memory cache for subsequent identical calls
-				self::$_inMemoryCache[$inMemoryKey] = $cachedResponse;
+				// Untrimmed, so later pages and searches get their own slice from it.
+				self::$_inMemoryCache[$cacheKey] = $cachedResponse;
 
 				if($cachedResponse != null && isset($params['listname']))
 				{

--- a/plugin.php
+++ b/plugin.php
@@ -163,20 +163,29 @@ add_action('admin_bar_menu', function ( $wp_admin_bar ) {
 
 add_action('admin_init', function () use ( $pDI ) {
     // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- strpos() doesn't execute or display the value, only checks string position.
-    if ( isset($_SERVER["REQUEST_URI"]) && strpos($_SERVER["REQUEST_URI"], "action=onoffice-clear-cache") !== false ) {
-        $onofficeSettingsCache = get_option('onoffice-settings-duration-cache');
-        $timestamp = wp_next_scheduled('oo_cache_renew');
-        if ($timestamp) {
-            wp_unschedule_event($timestamp, 'oo_cache_renew');
-        }
-
-        wp_schedule_event(time(), $onofficeSettingsCache, 'oo_cache_renew');
-        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- wp_safe_redirect() validates and sanitizes the URL.
-        $location = ! empty($_SERVER['HTTP_REFERER']) ? wp_unslash($_SERVER['HTTP_REFERER']) : admin_url('admin.php?page=onoffice-settings');
-        update_option('onoffice-notice-cache-was-cleared', true);
-        wp_safe_redirect($location);
-        exit();
+    if ( !isset($_SERVER["REQUEST_URI"]) || strpos($_SERVER["REQUEST_URI"], "action=onoffice-clear-cache") === false ) {
+        return;
     }
+
+    // Clear synchronously: a single DELETE plus a few delete_transient() calls, so the
+    // cache is provably empty by the time the redirect is answered. Doing this via cron
+    // made the success notice lie for up to one cron interval (10+ minutes on hosts that
+    // set DISABLE_WP_CRON and run wp-cron from the system crontab).
+    $pDI->get(CacheHandler::class)->clear();
+
+    // Warm the cache back up out-of-band. A single event on top of the recurring
+    // 'oo_cache_renew' schedule - never unschedule the recurring one here, because
+    // wp_schedule_event() returns false for an unknown recurrence name and the event
+    // would then be gone for good.
+    // WordPress itself skips a single event whose hook is already due within 10 minutes,
+    // so repeated clicks cannot pile up renewals.
+    wp_schedule_single_event(time(), 'oo_cache_renew');
+
+    // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- wp_safe_redirect() validates and sanitizes the URL.
+    $location = ! empty($_SERVER['HTTP_REFERER']) ? wp_unslash($_SERVER['HTTP_REFERER']) : admin_url('admin.php?page=onoffice-settings');
+    update_option('onoffice-notice-cache-was-cleared', true);
+    wp_safe_redirect($location);
+    exit();
 });
 
 // phpcs:disable WordPress.Security.NonceVerification.Recommended -- WordPress core edit action check, no side effects.

--- a/plugin/Cache/DBCache.php
+++ b/plugin/Cache/DBCache.php
@@ -180,15 +180,15 @@ class DBCache
 
 
 	/**
+	 * Deletes every entry, unconditionally.
 	 *
+	 * This used to delegate to cleanup() with a TTL of 0, which deletes
+	 * "WHERE UNIX_TIMESTAMP(cache_created) < time()". Entries written in the same
+	 * second compare equal rather than less and therefore survived - so a manual
+	 * "clear cache" left behind whatever the site had just cached.
 	 */
-
 	public function clearAll()
 	{
-		$oldTtl = $this->_options['ttl'];
-		$this->_options['ttl'] = 0;
-		$this->_options['cleanCache'] = true;
-		$this->cleanup();
-		$this->_options['ttl'] = $oldTtl;
+		$this->_pWpdb->query( "DELETE FROM {$this->_pWpdb->prefix}oo_plugin_cache" );
 	}
 }

--- a/plugin/Cache/DBCache.php
+++ b/plugin/Cache/DBCache.php
@@ -69,7 +69,7 @@ class DBCache
 	{
 		$onofficeSettingsCache = get_option('onoffice-settings-duration-cache');
 		$interval = $this->_options['ttl'];
-		if (!empty($onofficeSettingsCache) && !isset($this->_options['cleanCache'])) {
+		if (!empty($onofficeSettingsCache)) {
 			$interval = wp_get_schedules()[$onofficeSettingsCache]["interval"];
 		}
 

--- a/tests/TestClassApiCall.php
+++ b/tests/TestClassApiCall.php
@@ -1,0 +1,239 @@
+<?php
+
+/**
+ *
+ *    Copyright (C) 2026 onOffice GmbH
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Affero General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare (strict_types=1);
+
+namespace onOffice\tests;
+
+use onOffice\SDK\internal\ApiCall;
+use onOffice\SDK\internal\HttpFetch;
+use ReflectionProperty;
+use WP_UnitTestCase;
+
+/**
+ * Cache-key handling in ApiCall::collectOrGatherRequests().
+ *
+ * A list request carries the parameters the cron warmed the cache with in
+ * params_list_cache. The cache is looked up under those, so every page and every
+ * search of one list shares the warmed entry and gets its own slice from
+ * applyListCacheFiltering(). Duplicate detection must not share that key.
+ *
+ * Note: SDK/tests/ApiCallTest.php is not part of the phpunit.xml.dist test suite
+ * (it neither lives in ./tests/ nor uses the Test prefix), so these live here to
+ * actually run in CI.
+ *
+ * @covers onOffice\SDK\internal\ApiCall
+ */
+class TestClassApiCall
+	extends WP_UnitTestCase
+{
+	/**
+	 * ApiCall::$_inMemoryCache is static, so responses cached by one test would leak
+	 * into the next and turn an intended HTTP call into a silent cache hit.
+	 *
+	 * @before
+	 */
+	public function resetInMemoryCache()
+	{
+		$pInMemoryCache = new ReflectionProperty(ApiCall::class, '_inMemoryCache');
+		$pInMemoryCache->setAccessible(true);
+		$pInMemoryCache->setValue(null, []);
+	}
+
+
+	/**
+	 * Two searches on the same list share one cache entry on purpose - the entry the
+	 * cron warmed with the list's default filter. Duplicate detection must NOT share
+	 * that key: with a single key the second search is mistaken for a duplicate of the
+	 * first and served the first search's records, i.e. the wrong estates.
+	 */
+	public function testDifferentSearchesOnTheSameListAreNotTreatedAsDuplicates()
+	{
+		$pApiCall = new ApiCall();
+		$listCacheParameters = $this->buildListCacheParameters();
+
+		$buy = $this->queueSearch($pApiCall, $listCacheParameters, ['vermarktungsart' => [['op' => 'in', 'val' => ['kauf']]]]);
+		$rent = $this->queueSearch($pApiCall, $listCacheParameters, ['vermarktungsart' => [['op' => 'in', 'val' => ['miete']]]]);
+		$this->assertNotSame($buy, $rent);
+
+		$pApiCall->sendRequests('someToken', 'someSecret', $this->buildHttpFetch([
+			$this->buildRecordsResult([11, 12]),
+			$this->buildRecordsResult([21, 22]),
+		]), false);
+
+		$this->assertSame([11, 12], $this->recordIds($pApiCall->getResponse($buy)));
+		$this->assertSame([21, 22], $this->recordIds($pApiCall->getResponse($rent)));
+	}
+
+
+	/**
+	 * Same search queued twice is a real duplicate and must still collapse into one
+	 * HTTP action.
+	 */
+	public function testTheSameSearchQueuedTwiceStillDeduplicates()
+	{
+		$pApiCall = new ApiCall();
+		$listCacheParameters = $this->buildListCacheParameters();
+		$search = ['vermarktungsart' => [['op' => 'in', 'val' => ['kauf']]]];
+
+		$first = $this->queueSearch($pApiCall, $listCacheParameters, $search);
+		$second = $this->queueSearch($pApiCall, $listCacheParameters, $search);
+
+		$pHttpFetch = $this->buildHttpFetch([$this->buildRecordsResult([11, 12])], $this->once());
+		$pApiCall->sendRequests('someToken', 'someSecret', $pHttpFetch, false);
+
+		$this->assertSame([11, 12], $this->recordIds($pApiCall->getResponse($first)));
+		$this->assertSame([11, 12], $this->recordIds($pApiCall->getResponse($second)));
+	}
+
+
+	/**
+	 * Requests without params_list_cache must behave exactly as before the key split:
+	 * both keys are identical, so identical parameters collapse into one HTTP action.
+	 */
+	public function testIdenticalRequestsWithoutListCacheStillDeduplicate()
+	{
+		$pApiCall = new ApiCall();
+		$parameters = ['data' => ['Id'], 'listlimit' => 10];
+
+		$first = $pApiCall->callByRawData('read', '', null, 'estate', $parameters);
+		$second = $pApiCall->callByRawData('read', '', null, 'estate', $parameters);
+
+		$pHttpFetch = $this->buildHttpFetch([$this->buildRecordsResult([7])], $this->once());
+		$pApiCall->sendRequests('someToken', 'someSecret', $pHttpFetch, false);
+
+		$this->assertSame([7], $this->recordIds($pApiCall->getResponse($first)));
+		$this->assertSame([7], $this->recordIds($pApiCall->getResponse($second)));
+	}
+
+
+	/**
+	 * Different requests without params_list_cache stay separate, too.
+	 */
+	public function testDifferentRequestsWithoutListCacheStaySeparate()
+	{
+		$pApiCall = new ApiCall();
+
+		$first = $pApiCall->callByRawData('read', '', null, 'estate', ['data' => ['Id'], 'listlimit' => 10]);
+		$second = $pApiCall->callByRawData('read', '', null, 'estate', ['data' => ['Id'], 'listlimit' => 20]);
+
+		$pApiCall->sendRequests('someToken', 'someSecret', $this->buildHttpFetch([
+			$this->buildRecordsResult([1]),
+			$this->buildRecordsResult([2]),
+		]), false);
+
+		$this->assertSame([1], $this->recordIds($pApiCall->getResponse($first)));
+		$this->assertSame([2], $this->recordIds($pApiCall->getResponse($second)));
+	}
+
+
+	/**
+	 * The parameters SDKWrapper::renewCache() writes the formatted list entry under.
+	 *
+	 * @return array
+	 */
+	private function buildListCacheParameters(): array
+	{
+		return [
+			'listname' => 'Alle Immobilien',
+			'data' => ['Id'],
+			'filter' => ['veroeffentlichen' => [['op' => '=', 'val' => 1]]],
+			'outputlanguage' => 'DEU',
+			'formatoutput' => true,
+			'listlimit' => 500,
+		];
+	}
+
+
+	/**
+	 * Queue one paginated frontend list request with an active search, shaped like
+	 * EstateList::getEstateParameters() builds it.
+	 *
+	 * @param ApiCall $pApiCall
+	 * @param array $listCacheParameters
+	 * @param array $searchFilter
+	 * @return int request handle
+	 */
+	private function queueSearch(ApiCall $pApiCall, array $listCacheParameters, array $searchFilter): int
+	{
+		return $pApiCall->callByRawData('read', '', null, 'estate', [
+			'listname' => $listCacheParameters['listname'],
+			'data' => $listCacheParameters['data'],
+			'filter' => array_merge($listCacheParameters['filter'], $searchFilter),
+			'outputlanguage' => $listCacheParameters['outputlanguage'],
+			'formatoutput' => true,
+			'listlimit' => 16,
+			'listoffset' => 0,
+			'params_list_cache' => $listCacheParameters,
+		]);
+	}
+
+
+	/**
+	 * @param array $results One entry per expected API action, in queue order.
+	 * @param mixed $sendExpectation Optional PHPUnit invocation rule for send().
+	 * @return HttpFetch
+	 */
+	private function buildHttpFetch(array $results, $sendExpectation = null): HttpFetch
+	{
+		$pHttpFetch = $this->getMockBuilder(HttpFetch::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['send'])
+			->getMock();
+
+		$pInvocation = $sendExpectation === null
+			? $pHttpFetch->method('send')
+			: $pHttpFetch->expects($sendExpectation)->method('send');
+		$pInvocation->willReturn(json_encode(['response' => ['results' => $results]]));
+
+		return $pHttpFetch;
+	}
+
+
+	/**
+	 * @param int[] $ids
+	 * @return array
+	 */
+	private function buildRecordsResult(array $ids): array
+	{
+		$records = [];
+		foreach ($ids as $id) {
+			$records[] = ['id' => $id, 'type' => 'estate', 'elements' => ['Id' => $id]];
+		}
+
+		return [
+			'actionid' => 'read',
+			'resourcetype' => 'estate',
+			'status' => ['errorcode' => 0],
+			'data' => ['meta' => ['cntabsolute' => count($ids)], 'records' => $records],
+		];
+	}
+
+
+	/**
+	 * @param array|null $response
+	 * @return int[]
+	 */
+	private function recordIds($response): array
+	{
+		return array_map('intval', array_column($response['data']['records'] ?? [], 'id'));
+	}
+}

--- a/tests/TestClassDBCache.php
+++ b/tests/TestClassDBCache.php
@@ -38,6 +38,42 @@ class TestClassDBCache
 	extends WP_UnitTestCase
 {
 	/**
+	 * clearAll() used to run cleanup() with a TTL of 0, which deletes
+	 * "WHERE UNIX_TIMESTAMP(cache_created) < time()". Entries written in the same
+	 * second as the click compare equal, not less, and therefore survived a manual
+	 * "clear cache" - the exact complaint that started this investigation.
+	 */
+	public function testClearAllRemovesEntriesWrittenInTheSameSecond()
+	{
+		global $wpdb;
+		$table = $wpdb->prefix . 'oo_plugin_cache';
+		$pCache = new DBCache(['ttl' => 3600]);
+
+		$pCache->write(['parameters' => ['a' => 1]], 'first');
+		$pCache->write(['parameters' => ['b' => 2]], 'second');
+		$this->assertSame('2', $wpdb->get_var("SELECT COUNT(*) FROM $table"));
+
+		$pCache->clearAll();
+
+		$this->assertSame('0', $wpdb->get_var("SELECT COUNT(*) FROM $table"));
+	}
+
+
+	public function testClearAllRemovesEntriesRegardlessOfCacheDurationSetting()
+	{
+		global $wpdb;
+		$table = $wpdb->prefix . 'oo_plugin_cache';
+		update_option('onoffice-settings-duration-cache', 'six_hours');
+		$pCache = new DBCache(['ttl' => 3600]);
+
+		$pCache->write(['parameters' => ['c' => 3]], 'third');
+		$pCache->clearAll();
+
+		$this->assertSame('0', $wpdb->get_var("SELECT COUNT(*) FROM $table"));
+	}
+
+
+	/**
 	 * Different filters should produce different cache keys.
 	 * Before the fix, only the Id filter was included in the hash.
 	 */


### PR DESCRIPTION
## TL;DR

Two independent cache defects, both reproduced on live boxes:

1. **"Clear onOffice cache" does not clear the cache.** It only schedules a cron job. On hosts that set `DISABLE_WP_CRON` and run wp-cron from the system crontab, nothing happens for up to 10 minutes — while the success notice appears immediately. The button now clears synchronously (37 ms measured), so it behaves the same on every host.
2. **Estate lists with an active search are never cached.** Every single page view hits the onOffice API live, forever. They are now served from the entry the cron already warmed (135–169 ms → 0–5 ms measured, identical results).

Plus a smaller one: `clearAll()` left behind every entry written in the same second as the click.

6 new tests, 1348 green.

---

## 1. The clear-cache button never cleared anything

`plugin.php` did not clear the cache. It unscheduled and rescheduled `oo_cache_renew`, set the "cache was cleaned" notice, and redirected:

```php
wp_schedule_event(time(), $onofficeSettingsCache, 'oo_cache_renew');
update_option('onoffice-notice-cache-was-cleared', true);
```

Whether anything actually happened then depends entirely on how the host runs WP-Cron. Measured on three environments:

| Environment | `DISABLE_WP_CRON` | wp-cron runner | Delay after the click |
|---|---|---|---|
| Raidboxes A | `true` | system crontab `*/10` | **0–10 minutes** |
| Raidboxes B | `false` | page load | ~1 second |
| IONOS | not set | supervisor loop, 60 s | ~1–60 seconds |

Same plugin version, same site content — only the host configuration differs. This is why the button is reported as broken on some sites and working on others, and why the report is hard to reproduce.

Verified directly on the slow box: `rows=125` before the click, `rows=125` immediately after, unchanged.

**Fix:** call `CacheHandler::clear()` in the request. It is one `DELETE` plus a handful of `delete_transient()` calls — 37 ms measured, so the redirect is not noticeably delayed and the success notice is now truthful. The warm-up stays out of band via `wp_schedule_single_event()`.

The old code also unscheduled the recurring event *before* rescheduling it. `wp_schedule_event()` returns `false` for a recurrence name that no `cron_schedules` entry provides, so a failed reschedule left the site with no cache renewal at all — permanently, since the reschedule is only attempted when the event is missing or the setting changes. The recurring event is no longer touched.

## 2. `clearAll()` did not clear all

```php
$this->_options['ttl'] = 0;
$this->cleanup();       // DELETE ... WHERE UNIX_TIMESTAMP(cache_created) < %d
```

With a TTL of 0 the cutoff is `time()`, and `<` does not match rows written in the current second. Reproduced: write two entries, call `clearAll()`, both survive.

The intent was always "delete everything" — `88aa3fb0` ("fix bug clear cache") already had to add a `cleanCache` flag to stop the cache-duration setting from overriding the zero TTL. The boundary was missed. `clearAll()` is now a plain unconditional `DELETE`, which also makes the `cleanCache` flag unnecessary.

`cleanup()` — the method where the TTL is meaningful — is unchanged.

## 3. Searched estate lists were never cached

The DB cache key for a list request is `md5(listname | formatoutput | outputlanguage | filter)`.

- The cron warms the cache using `DefaultFilterBuilder::getDefaultFilter()` — the list's default filter.
- The frontend reads using `DefaultFilterBuilder::buildFilter()` — the default filter **plus** the active search criteria, geo filter, favourites ids, and so on.

As soon as a visitor searches, the filter differs, so the key differs and the lookup misses. The response is fetched live, and `writeCacheForResponses()` then refuses to store it because it is a truncated page:

```php
if ($isBeyondFirstPage || $isTruncated) {
    continue;
}
```

So the entry is never created, and the next visitor repeats the whole thing. Measured on a test box after warming the cache — the searched list is consistently slower and produces no list cache entry:

```
GET /immobilien/                      0.81s  0.83s
GET /immobilien/?vermarktungsart=kauf 1.16s  1.14s
```

**Fix:** a list request already carries the parameters the cron warmed it under, in `params_list_cache`. The cache is now looked up under those, and `applyListCacheFiltering()` trims the full set down to the requested page — exactly what that method already does on the unsearched path.

### Why there are two keys

```php
$cacheKey   = $this->getInMemoryCacheKey($cacheParameters);
$requestKey = $this->getInMemoryCacheKey($usedParameters);
```

`$cacheKey` is deliberately shared by every page and every search of one list — that sharing is the point. `$requestKey` stays unique per request and is the only key `$sourceRequestIdByCacheKey` may use.

This matters: duplicate detection keyed by `$cacheKey` makes two different searches on the same list look like duplicates of each other, and the second one is served the first one's records — wrong estates, not just stale ones. `TestClassApiCall::testDifferentSearchesOnTheSameListAreNotTreatedAsDuplicates` fails with a single key and passes with two.

Requests without `params_list_cache` produce identical keys, so everything outside list views behaves exactly as before.

## Verification

Every search combination was compared against a cache-free live API call on a real box — identical estate ids in all cases:

| Search | live ids | cached ids | live | cached |
|---|---|---|---|---|
| (no search) | 16 | 16 | 153 ms | 5 ms |
| `vermarktungsart=kauf` | 16 | 16 | 169 ms | 0 ms |
| `vermarktungsart=miete` | 2 | 2 | 135 ms | 0 ms |
| `objektart in haus,wohnung` | 16 | 16 | 137 ms | 0 ms |
| `kaufpreis 100k..400k` | 6 | 6 | 135 ms | 0 ms |
| `anzahl_zimmer >= 3` | 11 | 11 | 146 ms | 0 ms |

The three raw-output paths were checked and none of them reach the new lookup, so the `formatoutput` guard inside `applyListCacheFiltering()` cannot be bypassed:

- `EstateList::loadEstates()` unsets `params_list_cache` for the raw request
- `fetchDataForOrderEstatesByTags()` requires `$formatOutput === true`
- `getEstateParametersForMap()` never sets `params_list_cache`

## Tests

- `tests/TestClassDBCache.php` — `clearAll()` removes entries written in the same second, and does so regardless of the cache-duration setting
- `tests/TestClassApiCall.php` — different searches on one list stay separate; the same search still deduplicates; requests without `params_list_cache` behave unchanged

1348 tests green (1342 before).

Note: `SDK/tests/ApiCallTest.php` is not covered by `phpunit.xml.dist` — it is neither under `./tests/` nor uses the `Test` prefix — so it never runs in CI. The new SDK tests were placed in `tests/` to actually be part of the gate.

## Risk

Item 3 touches the cache lookup that every request on every site goes through. The safety property is that both keys are identical for anything without `params_list_cache`, which is every request outside estate list views.
