### PR TITLE
fix: clear the cache on demand and cache searched estate lists

### DIFF
--- a/SDK/src/internal/ApiCall.php
+++ b/SDK/src/internal/ApiCall.php
@@ -225,11 +225,27 @@ class ApiCall
 			);
 			$params = $usedParameters["parameters"];
 
-			// 1. Check in-memory cache first (catches ALL duplicate calls within this PHP request)
-			$inMemoryKey = $this->getInMemoryCacheKey($usedParameters);
-			if (isset(self::$_inMemoryCache[$inMemoryKey]))
+			// params_list_cache holds the parameters the cron warmed the list under:
+			// same list, default filter, complete record set. Look the cache up under
+			// those, so a request with an active search hits the entry at all, and let
+			// applyListCacheFiltering() below trim the full set to this page.
+			$cacheParameters = $usedParameters;
+			if (isset($params['params_list_cache']) && is_array($params['params_list_cache']))
 			{
-				$inMemoryResponse = self::$_inMemoryCache[$inMemoryKey];
+				$cacheParameters['parameters'] = $params['params_list_cache'];
+			}
+
+			// $cacheKey is shared by every page and search of one list, $requestKey is not.
+			// Duplicate detection must use $requestKey: keyed by $cacheKey, two different
+			// searches on the same list look like duplicates and the second one gets the
+			// first one's records. See TestClassApiCall.
+			$cacheKey = $this->getInMemoryCacheKey($cacheParameters);
+			$requestKey = $this->getInMemoryCacheKey($usedParameters);
+
+			// 1. Check in-memory cache first (catches ALL duplicate calls within this PHP request)
+			if (isset(self::$_inMemoryCache[$cacheKey]))
+			{
+				$inMemoryResponse = self::$_inMemoryCache[$cacheKey];
 				// Apply list-specific filtering/sorting if needed (same logic as DB cache hit)
 				if (isset($params['listname']))
 				{
@@ -239,14 +255,21 @@ class ApiCall
 				continue;
 			}
 
+			// Exact response for this request, stored after an HTTP fetch below - already trimmed.
+			if ($cacheKey !== $requestKey && isset(self::$_inMemoryCache[$requestKey]))
+			{
+				$this->_responses[$requestId] = new Response($pRequest, self::$_inMemoryCache[$requestKey]);
+				continue;
+			}
+
 			// 2. Check DB cache (existing logic for list-based caching)
-			$cachedResponse = $this->getFromCache($usedParameters);
+			$cachedResponse = $this->getFromCache($cacheParameters);
 
 			if ($cachedResponse === null)
 			{
-				if (isset($sourceRequestIdByCacheKey[$inMemoryKey]))
+				if (isset($sourceRequestIdByCacheKey[$requestKey]))
 				{
-					$sourceRequestId = $sourceRequestIdByCacheKey[$inMemoryKey];
+					$sourceRequestId = $sourceRequestIdByCacheKey[$requestKey];
 					if (!isset($duplicateRequestsBySourceRequestId[$sourceRequestId]))
 					{
 						$duplicateRequestsBySourceRequestId[$sourceRequestId] = array();
@@ -268,12 +291,12 @@ class ApiCall
 
 				$actionParameters[] = $parametersThisAction;
 				$actionParametersOrder[] = $pRequest;
-				$sourceRequestIdByCacheKey[$inMemoryKey] = $requestId;
+				$sourceRequestIdByCacheKey[$requestKey] = $requestId;
 			}
 			else
 			{
-				// Store in in-memory cache for subsequent identical calls
-				self::$_inMemoryCache[$inMemoryKey] = $cachedResponse;
+				// Untrimmed, so later pages and searches get their own slice from it.
+				self::$_inMemoryCache[$cacheKey] = $cachedResponse;
 
 				if($cachedResponse != null && isset($params['listname']))
 				{

--- a/plugin.php
+++ b/plugin.php
@@ -163,20 +163,29 @@ add_action('admin_bar_menu', function ( $wp_admin_bar ) {
 
 add_action('admin_init', function () use ( $pDI ) {
     // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- strpos() doesn't execute or display the value, only checks string position.
-    if ( isset($_SERVER["REQUEST_URI"]) && strpos($_SERVER["REQUEST_URI"], "action=onoffice-clear-cache") !== false ) {
-        $onofficeSettingsCache = get_option('onoffice-settings-duration-cache');
-        $timestamp = wp_next_scheduled('oo_cache_renew');
-        if ($timestamp) {
-            wp_unschedule_event($timestamp, 'oo_cache_renew');
-        }
-
-        wp_schedule_event(time(), $onofficeSettingsCache, 'oo_cache_renew');
-        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- wp_safe_redirect() validates and sanitizes the URL.
-        $location = ! empty($_SERVER['HTTP_REFERER']) ? wp_unslash($_SERVER['HTTP_REFERER']) : admin_url('admin.php?page=onoffice-settings');
-        update_option('onoffice-notice-cache-was-cleared', true);
-        wp_safe_redirect($location);
-        exit();
+    if ( !isset($_SERVER["REQUEST_URI"]) || strpos($_SERVER["REQUEST_URI"], "action=onoffice-clear-cache") === false ) {
+        return;
     }
+
+    // Clear synchronously: a single DELETE plus a few delete_transient() calls, so the
+    // cache is provably empty by the time the redirect is answered. Doing this via cron
+    // made the success notice lie for up to one cron interval (10+ minutes on hosts that
+    // set DISABLE_WP_CRON and run wp-cron from the system crontab).
+    $pDI->get(CacheHandler::class)->clear();
+
+    // Warm the cache back up out-of-band. A single event on top of the recurring
+    // 'oo_cache_renew' schedule - never unschedule the recurring one here, because
+    // wp_schedule_event() returns false for an unknown recurrence name and the event
+    // would then be gone for good.
+    // WordPress itself skips a single event whose hook is already due within 10 minutes,
+    // so repeated clicks cannot pile up renewals.
+    wp_schedule_single_event(time(), 'oo_cache_renew');
+
+    // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- wp_safe_redirect() validates and sanitizes the URL.
+    $location = ! empty($_SERVER['HTTP_REFERER']) ? wp_unslash($_SERVER['HTTP_REFERER']) : admin_url('admin.php?page=onoffice-settings');
+    update_option('onoffice-notice-cache-was-cleared', true);
+    wp_safe_redirect($location);
+    exit();
 });
 
 // phpcs:disable WordPress.Security.NonceVerification.Recommended -- WordPress core edit action check, no side effects.

--- a/plugin/Cache/DBCache.php
+++ b/plugin/Cache/DBCache.php
@@ -180,15 +180,15 @@ class DBCache
 
 
 	/**
+	 * Deletes every entry, unconditionally.
 	 *
+	 * This used to delegate to cleanup() with a TTL of 0, which deletes
+	 * "WHERE UNIX_TIMESTAMP(cache_created) < time()". Entries written in the same
+	 * second compare equal rather than less and therefore survived - so a manual
+	 * "clear cache" left behind whatever the site had just cached.
 	 */
-
 	public function clearAll()
 	{
-		$oldTtl = $this->_options['ttl'];
-		$this->_options['ttl'] = 0;
-		$this->_options['cleanCache'] = true;
-		$this->cleanup();
-		$this->_options['ttl'] = $oldTtl;
+		$this->_pWpdb->query( "DELETE FROM {$this->_pWpdb->prefix}oo_plugin_cache" );
 	}
 }

--- a/plugin/Cache/DBCache.php
+++ b/plugin/Cache/DBCache.php
@@ -69,7 +69,7 @@ class DBCache
 	{
 		$onofficeSettingsCache = get_option('onoffice-settings-duration-cache');
 		$interval = $this->_options['ttl'];
-		if (!empty($onofficeSettingsCache) && !isset($this->_options['cleanCache'])) {
+		if (!empty($onofficeSettingsCache)) {
 			$interval = wp_get_schedules()[$onofficeSettingsCache]["interval"];
 		}
 

--- a/tests/TestClassApiCall.php
+++ b/tests/TestClassApiCall.php
@@ -1,0 +1,239 @@
+<?php
+
+/**
+ *
+ *    Copyright (C) 2026 onOffice GmbH
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Affero General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare (strict_types=1);
+
+namespace onOffice\tests;
+
+use onOffice\SDK\internal\ApiCall;
+use onOffice\SDK\internal\HttpFetch;
+use ReflectionProperty;
+use WP_UnitTestCase;
+
+/**
+ * Cache-key handling in ApiCall::collectOrGatherRequests().
+ *
+ * A list request carries the parameters the cron warmed the cache with in
+ * params_list_cache. The cache is looked up under those, so every page and every
+ * search of one list shares the warmed entry and gets its own slice from
+ * applyListCacheFiltering(). Duplicate detection must not share that key.
+ *
+ * Note: SDK/tests/ApiCallTest.php is not part of the phpunit.xml.dist test suite
+ * (it neither lives in ./tests/ nor uses the Test prefix), so these live here to
+ * actually run in CI.
+ *
+ * @covers onOffice\SDK\internal\ApiCall
+ */
+class TestClassApiCall
+	extends WP_UnitTestCase
+{
+	/**
+	 * ApiCall::$_inMemoryCache is static, so responses cached by one test would leak
+	 * into the next and turn an intended HTTP call into a silent cache hit.
+	 *
+	 * @before
+	 */
+	public function resetInMemoryCache()
+	{
+		$pInMemoryCache = new ReflectionProperty(ApiCall::class, '_inMemoryCache');
+		$pInMemoryCache->setAccessible(true);
+		$pInMemoryCache->setValue(null, []);
+	}
+
+
+	/**
+	 * Two searches on the same list share one cache entry on purpose - the entry the
+	 * cron warmed with the list's default filter. Duplicate detection must NOT share
+	 * that key: with a single key the second search is mistaken for a duplicate of the
+	 * first and served the first search's records, i.e. the wrong estates.
+	 */
+	public function testDifferentSearchesOnTheSameListAreNotTreatedAsDuplicates()
+	{
+		$pApiCall = new ApiCall();
+		$listCacheParameters = $this->buildListCacheParameters();
+
+		$buy = $this->queueSearch($pApiCall, $listCacheParameters, ['vermarktungsart' => [['op' => 'in', 'val' => ['kauf']]]]);
+		$rent = $this->queueSearch($pApiCall, $listCacheParameters, ['vermarktungsart' => [['op' => 'in', 'val' => ['miete']]]]);
+		$this->assertNotSame($buy, $rent);
+
+		$pApiCall->sendRequests('someToken', 'someSecret', $this->buildHttpFetch([
+			$this->buildRecordsResult([11, 12]),
+			$this->buildRecordsResult([21, 22]),
+		]), false);
+
+		$this->assertSame([11, 12], $this->recordIds($pApiCall->getResponse($buy)));
+		$this->assertSame([21, 22], $this->recordIds($pApiCall->getResponse($rent)));
+	}
+
+
+	/**
+	 * Same search queued twice is a real duplicate and must still collapse into one
+	 * HTTP action.
+	 */
+	public function testTheSameSearchQueuedTwiceStillDeduplicates()
+	{
+		$pApiCall = new ApiCall();
+		$listCacheParameters = $this->buildListCacheParameters();
+		$search = ['vermarktungsart' => [['op' => 'in', 'val' => ['kauf']]]];
+
+		$first = $this->queueSearch($pApiCall, $listCacheParameters, $search);
+		$second = $this->queueSearch($pApiCall, $listCacheParameters, $search);
+
+		$pHttpFetch = $this->buildHttpFetch([$this->buildRecordsResult([11, 12])], $this->once());
+		$pApiCall->sendRequests('someToken', 'someSecret', $pHttpFetch, false);
+
+		$this->assertSame([11, 12], $this->recordIds($pApiCall->getResponse($first)));
+		$this->assertSame([11, 12], $this->recordIds($pApiCall->getResponse($second)));
+	}
+
+
+	/**
+	 * Requests without params_list_cache must behave exactly as before the key split:
+	 * both keys are identical, so identical parameters collapse into one HTTP action.
+	 */
+	public function testIdenticalRequestsWithoutListCacheStillDeduplicate()
+	{
+		$pApiCall = new ApiCall();
+		$parameters = ['data' => ['Id'], 'listlimit' => 10];
+
+		$first = $pApiCall->callByRawData('read', '', null, 'estate', $parameters);
+		$second = $pApiCall->callByRawData('read', '', null, 'estate', $parameters);
+
+		$pHttpFetch = $this->buildHttpFetch([$this->buildRecordsResult([7])], $this->once());
+		$pApiCall->sendRequests('someToken', 'someSecret', $pHttpFetch, false);
+
+		$this->assertSame([7], $this->recordIds($pApiCall->getResponse($first)));
+		$this->assertSame([7], $this->recordIds($pApiCall->getResponse($second)));
+	}
+
+
+	/**
+	 * Different requests without params_list_cache stay separate, too.
+	 */
+	public function testDifferentRequestsWithoutListCacheStaySeparate()
+	{
+		$pApiCall = new ApiCall();
+
+		$first = $pApiCall->callByRawData('read', '', null, 'estate', ['data' => ['Id'], 'listlimit' => 10]);
+		$second = $pApiCall->callByRawData('read', '', null, 'estate', ['data' => ['Id'], 'listlimit' => 20]);
+
+		$pApiCall->sendRequests('someToken', 'someSecret', $this->buildHttpFetch([
+			$this->buildRecordsResult([1]),
+			$this->buildRecordsResult([2]),
+		]), false);
+
+		$this->assertSame([1], $this->recordIds($pApiCall->getResponse($first)));
+		$this->assertSame([2], $this->recordIds($pApiCall->getResponse($second)));
+	}
+
+
+	/**
+	 * The parameters SDKWrapper::renewCache() writes the formatted list entry under.
+	 *
+	 * @return array
+	 */
+	private function buildListCacheParameters(): array
+	{
+		return [
+			'listname' => 'Alle Immobilien',
+			'data' => ['Id'],
+			'filter' => ['veroeffentlichen' => [['op' => '=', 'val' => 1]]],
+			'outputlanguage' => 'DEU',
+			'formatoutput' => true,
+			'listlimit' => 500,
+		];
+	}
+
+
+	/**
+	 * Queue one paginated frontend list request with an active search, shaped like
+	 * EstateList::getEstateParameters() builds it.
+	 *
+	 * @param ApiCall $pApiCall
+	 * @param array $listCacheParameters
+	 * @param array $searchFilter
+	 * @return int request handle
+	 */
+	private function queueSearch(ApiCall $pApiCall, array $listCacheParameters, array $searchFilter): int
+	{
+		return $pApiCall->callByRawData('read', '', null, 'estate', [
+			'listname' => $listCacheParameters['listname'],
+			'data' => $listCacheParameters['data'],
+			'filter' => array_merge($listCacheParameters['filter'], $searchFilter),
+			'outputlanguage' => $listCacheParameters['outputlanguage'],
+			'formatoutput' => true,
+			'listlimit' => 16,
+			'listoffset' => 0,
+			'params_list_cache' => $listCacheParameters,
+		]);
+	}
+
+
+	/**
+	 * @param array $results One entry per expected API action, in queue order.
+	 * @param mixed $sendExpectation Optional PHPUnit invocation rule for send().
+	 * @return HttpFetch
+	 */
+	private function buildHttpFetch(array $results, $sendExpectation = null): HttpFetch
+	{
+		$pHttpFetch = $this->getMockBuilder(HttpFetch::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['send'])
+			->getMock();
+
+		$pInvocation = $sendExpectation === null
+			? $pHttpFetch->method('send')
+			: $pHttpFetch->expects($sendExpectation)->method('send');
+		$pInvocation->willReturn(json_encode(['response' => ['results' => $results]]));
+
+		return $pHttpFetch;
+	}
+
+
+	/**
+	 * @param int[] $ids
+	 * @return array
+	 */
+	private function buildRecordsResult(array $ids): array
+	{
+		$records = [];
+		foreach ($ids as $id) {
+			$records[] = ['id' => $id, 'type' => 'estate', 'elements' => ['Id' => $id]];
+		}
+
+		return [
+			'actionid' => 'read',
+			'resourcetype' => 'estate',
+			'status' => ['errorcode' => 0],
+			'data' => ['meta' => ['cntabsolute' => count($ids)], 'records' => $records],
+		];
+	}
+
+
+	/**
+	 * @param array|null $response
+	 * @return int[]
+	 */
+	private function recordIds($response): array
+	{
+		return array_map('intval', array_column($response['data']['records'] ?? [], 'id'));
+	}
+}

--- a/tests/TestClassDBCache.php
+++ b/tests/TestClassDBCache.php
@@ -38,6 +38,42 @@ class TestClassDBCache
 	extends WP_UnitTestCase
 {
 	/**
+	 * clearAll() used to run cleanup() with a TTL of 0, which deletes
+	 * "WHERE UNIX_TIMESTAMP(cache_created) < time()". Entries written in the same
+	 * second as the click compare equal, not less, and therefore survived a manual
+	 * "clear cache" - the exact complaint that started this investigation.
+	 */
+	public function testClearAllRemovesEntriesWrittenInTheSameSecond()
+	{
+		global $wpdb;
+		$table = $wpdb->prefix . 'oo_plugin_cache';
+		$pCache = new DBCache(['ttl' => 3600]);
+
+		$pCache->write(['parameters' => ['a' => 1]], 'first');
+		$pCache->write(['parameters' => ['b' => 2]], 'second');
+		$this->assertSame('2', $wpdb->get_var("SELECT COUNT(*) FROM $table"));
+
+		$pCache->clearAll();
+
+		$this->assertSame('0', $wpdb->get_var("SELECT COUNT(*) FROM $table"));
+	}
+
+
+	public function testClearAllRemovesEntriesRegardlessOfCacheDurationSetting()
+	{
+		global $wpdb;
+		$table = $wpdb->prefix . 'oo_plugin_cache';
+		update_option('onoffice-settings-duration-cache', 'six_hours');
+		$pCache = new DBCache(['ttl' => 3600]);
+
+		$pCache->write(['parameters' => ['c' => 3]], 'third');
+		$pCache->clearAll();
+
+		$this->assertSame('0', $wpdb->get_var("SELECT COUNT(*) FROM $table"));
+	}
+
+
+	/**
 	 * Different filters should produce different cache keys.
 	 * Before the fix, only the Id filter was included in the hash.
 	 */

--- a/tests/TestClassDBCache.php
+++ b/tests/TestClassDBCache.php
@@ -24,6 +24,8 @@ declare (strict_types=1);
 namespace onOffice\tests;
 
 use onOffice\WPlugin\Cache\DBCache;
+use onOffice\WPlugin\Installer\DatabaseChanges;
+use onOffice\WPlugin\WP\WPOptionWrapperTest;
 use ReflectionMethod;
 use WP_UnitTestCase;
 
@@ -37,6 +39,17 @@ use WP_UnitTestCase;
 class TestClassDBCache
 	extends WP_UnitTestCase
 {
+	public function set_up()
+	{
+		parent::set_up();
+		global $wpdb;
+		$pDbChanges = new DatabaseChanges(new WPOptionWrapperTest(), $wpdb);
+		$getCreateQueryCache = new ReflectionMethod(DatabaseChanges::class, 'getCreateQueryCache');
+		$getCreateQueryCache->setAccessible(true);
+		$createTable = str_replace('CREATE TABLE ', 'CREATE TABLE IF NOT EXISTS ', $getCreateQueryCache->invoke($pDbChanges));
+		$wpdb->query($createTable);
+	}
+
 	/**
 	 * clearAll() used to run cleanup() with a TTL of 0, which deletes
 	 * "WHERE UNIX_TIMESTAMP(cache_created) < time()". Entries written in the same


### PR DESCRIPTION
Cherry-pick der Cache-Fixes aus #1308 auf beta, damit nur diese Fixes (ohne den offenen Master-Stand) in prerelease/release landen.

- fix: improve cache clearing
- fix: simplify cache interval
- fix: serve searched estate lists from the warmed list cache